### PR TITLE
Add centralized versioning system and update examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,7 @@ jobs:
         components: rustfmt, clippy
 
     - name: Check formatting
+      id: fmt
       run: cargo fmt --all -- --check
 
     - name: Build
@@ -38,3 +39,6 @@ jobs:
 
     - name: Lint with clippy
       run: cargo clippy -- -D warnings
+
+  outputs:
+    fmt-status: ${{ steps.fmt.outcome }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  check-code-format:
+    name: Check Code Format
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,19 @@ jobs:
         components: rustfmt, clippy
 
     - name: Check formatting
-      id: fmt
       run: cargo fmt --all -- --check
+
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
 
     - name: Build
       run: cargo build --verbose
@@ -39,6 +50,3 @@ jobs:
 
     - name: Lint with clippy
       run: cargo clippy -- -D warnings
-
-outputs:
-  fmt-status: ${{ jobs.build.steps.fmt.outcome }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,5 +40,5 @@ jobs:
     - name: Lint with clippy
       run: cargo clippy -- -D warnings
 
-  outputs:
-    fmt-status: ${{ steps.fmt.outcome }}
+outputs:
+  fmt-status: ${{ jobs.build.steps.fmt.outcome }}

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 [![Crates.io Downloads](https://img.shields.io/crates/d/purecv.svg)](https://crates.io/crates/purecv)
 [![GitHub Stars](https://img.shields.io/github/stars/webarkit/purecv.svg?style=social)](https://github.com/webarkit/purecv/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/webarkit/purecv.svg?style=social)](https://github.com/webarkit/purecv/network/members)
-[![Cargo Fmt](https://github.com/webarkit/purecv/workflows/Check%20Code%20Format/badge.svg)](https://github.com/webarkit/purecv/actions?query=workflow%3A%22Check+Code+Format%22)
 
 A high-performance, **pure Rust** computer vision library focusing on the `core` and `imgproc` modules of OpenCV. **PureCV** is built from the ground up to be memory-safe, thread-safe, and highly portable without the overhead of C++ FFI.
+
+> This project is currently a **Work in Progress**. While most core and imgproc features have been implemented, the library is not yet stable, and bugs may occur. We are actively optimizing and expanding the feature set.
 
 ## 🎯 Philosophy
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ![PureCv Banner](./assets/purecv_banner.png)
 
 [![Rust CI](https://github.com/webarkit/purecv/actions/workflows/rust.yml/badge.svg)](https://github.com/webarkit/purecv/actions/workflows/rust.yml)
+[![Crates.io](https://img.shields.io/crates/v/purecv.svg)](https://crates.io/crates/purecv)
+[![Crates.io Downloads](https://img.shields.io/crates/d/purecv.svg)](https://crates.io/crates/purecv)
+[![GitHub Stars](https://img.shields.io/github/stars/webarkit/purecv.svg?style=social)](https://github.com/webarkit/purecv/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/webarkit/purecv.svg?style=social)](https://github.com/webarkit/purecv/network/members)
+[![Cargo Fmt](https://github.com/webarkit/purecv/workflows/Check%20Code%20Format/badge.svg)](https://github.com/webarkit/purecv/actions?query=workflow%3A%22Check+Code+Format%22)
 
 A high-performance, **pure Rust** computer vision library focusing on the `core` and `imgproc` modules of OpenCV. **PureCV** is built from the ground up to be memory-safe, thread-safe, and highly portable without the overhead of C++ FFI.
 

--- a/examples/arithmetic.rs
+++ b/examples/arithmetic.rs
@@ -36,9 +36,11 @@
 
 use purecv::core::arithm::{add, multiply};
 use purecv::core::Matrix;
+use purecv::version;
 
 fn main() {
     println!("--- purecv Basic Arithmetic Example ---");
+    println!("purecv v{}", version::get_version());
 
     // 1. Create two 3x3 matrices with 1 channel (u8)
     let m1 = Matrix::<u8>::from_vec(3, 3, 1, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/examples/color_conversion.rs
+++ b/examples/color_conversion.rs
@@ -36,9 +36,11 @@
 
 use purecv::core::Matrix;
 use purecv::imgproc::{cvt_color, ColorConversionCode};
+use purecv::version;
 
 fn main() {
     println!("--- purecv Color Conversion Example ---");
+    println!("purecv v{}", version::get_version());
 
     // 1. Create a 3x3 RGB matrix (3 channels)
     // Representing a simple gradient

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -40,10 +40,12 @@ use purecv::imgproc::{
     bilateral_filter, blur, canny, cvt_color_rgb_to_gray, gaussian_blur, laplacian, median_blur,
     scharr, sobel,
 };
+use purecv::version;
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("--- purecv Filters Example ---");
+    println!("purecv v{}", version::get_version());
 
     // 1. Load the image
     let img_path = "examples/data/butterfly.jpg";

--- a/examples/structural_ops.rs
+++ b/examples/structural_ops.rs
@@ -36,9 +36,11 @@
 
 use purecv::core::structural::{copy_make_border, flip, merge, repeat, rotate, split, transpose};
 use purecv::core::{Matrix, Scalar};
+use purecv::version;
 
 fn main() {
     println!("--- purecv Structural Operations Example ---");
+    println!("purecv v{}", version::get_version());
 
     // Start with a 2x3 matrix
     let m = Matrix::<u8>::from_vec(2, 3, 1, vec![1, 2, 3, 4, 5, 6]);

--- a/examples/threshold.rs
+++ b/examples/threshold.rs
@@ -36,9 +36,11 @@
 
 use purecv::core::Matrix;
 use purecv::imgproc::{threshold, ThresholdTypes};
+use purecv::version;
 
 fn main() {
     println!("--- purecv Threshold Example ---\n");
+    println!("purecv v{}", version::get_version());
 
     // 1. Create a 4x4 grayscale matrix with a gradient
     let data: Vec<u8> = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 pub mod core;
 pub mod features;
 pub mod imgproc;
+pub mod version;
 
 /// Prelude to easily import common structures
 pub mod prelude {

--- a/src/version.rs
+++ b/src/version.rs
@@ -83,10 +83,7 @@ mod tests {
         let v = get_version();
 
         // Only validate the numeric core (major.minor[.patch]) before any pre-release/build suffix.
-        let core = v
-            .split(|c| c == '-' || c == '+')
-            .next()
-            .unwrap_or(v);
+        let core = v.split(|c| c == '-' || c == '+').next().unwrap_or(v);
 
         let parts: Vec<&str> = core.split('.').collect();
         assert!(

--- a/src/version.rs
+++ b/src/version.rs
@@ -47,7 +47,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// # Example
 ///
 /// ```rust
-/// use webarkitlib_rs::version::get_version;
+/// use purecv::version::get_version;
 /// let v = get_version();
 /// assert!(!v.is_empty());
 /// ```

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,103 @@
+/*
+ *  version.rs
+ *  purecv
+ *
+ *  This file is part of purecv - WebARKit.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! # Version
+//!
+//! Provides the library version string sourced directly from `Cargo.toml` at
+//! compile time, along with helper functions to retrieve and display it.
+
+/// The current version of `purecv`, sourced from `Cargo.toml` at compile time.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Returns the current version string of the library.
+///
+/// # Example
+///
+/// ```rust
+/// use webarkitlib_rs::version::get_version;
+/// let v = get_version();
+/// assert!(!v.is_empty());
+/// ```
+pub fn get_version() -> &'static str {
+    VERSION
+}
+
+/// Logs the library name and version using the [`log`] crate at `info` level.
+///
+/// Call this early in your application (e.g. during initialization) so the
+/// version appears in the console / log output.
+pub fn print_version() {
+    log::info!("purecv v{}", VERSION);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_version_is_not_empty() {
+        assert!(!get_version().is_empty());
+    }
+
+    #[test]
+    fn test_version_constant_matches_getter() {
+        assert_eq!(VERSION, get_version());
+    }
+
+    #[test]
+    fn test_version_format() {
+        // Version should be a valid semver-like string, e.g. "0.1.4" or "0.1.4-alpha.1"
+        let v = get_version();
+
+        // Only validate the numeric core (major.minor[.patch]) before any pre-release/build suffix.
+        let core = v
+            .split(|c| c == '-' || c == '+')
+            .next()
+            .unwrap_or(v);
+
+        let parts: Vec<&str> = core.split('.').collect();
+        assert!(
+            parts.len() >= 2,
+            "Version should have at least major.minor parts in the numeric core"
+        );
+        for part in &parts {
+            assert!(
+                part.parse::<u64>().is_ok(),
+                "Each numeric core version part should be purely numeric"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new versioning module to the `purecv` library, making it easier to access and display the library's version at runtime. It also updates the example programs to print the current version, improves project documentation with more badges, and reorganizes the CI workflow for better clarity.

**Versioning improvements:**

* Added a new `version` module (`src/version.rs`) that provides a compile-time version string sourced from `Cargo.toml`, along with helper functions to retrieve and log the version. Includes tests for version correctness.
* Exposed the new `version` module in the library's public API via `src/lib.rs`.

**Example updates:**

* Updated all example programs (`arithmetic.rs`, `color_conversion.rs`, `filters.rs`, `structural_ops.rs`, `threshold.rs`) to print the current `purecv` version at startup by calling `version::get_version()`. [[1]](diffhunk://#diff-929d2f048e51790967615d7ea4c9cd377a6c579e9688f20d5ade4d704b24900aR39-R43) [[2]](diffhunk://#diff-ba3c966bde6a76044a6989c3a8537422313f5f6bc4265f78b389101e2ad433d6R39-R43) [[3]](diffhunk://#diff-d9a9566e5f04ec32c23246707cdbbac4cd9e4e0e81a5795d88a6e4528e845c56R43-R48) [[4]](diffhunk://#diff-521c7812b2754fc977d23110be7307186a7160ea48d4d154667d343d0461ae52R39-R43) [[5]](diffhunk://#diff-3fdd7ad052596d41dce3dd3509cea7a378fa5637b1c85fdb2689f724654f5a09R39-R43)

**Documentation enhancements:**

* Added badges for Crates.io version, downloads, GitHub stars, and forks to `README.md` for improved project visibility and status. Also added a note about the project's work-in-progress status.

**CI workflow improvements:**

* Split the Rust CI workflow into two jobs: `check-code-format` (for formatting checks) and `build` (for building and testing), improving clarity and separation of concerns in `.github/workflows/rust.yml`. [[1]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL12-R13) [[2]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR27-R38)