### PR TITLE
feat(core): implement Scalar improvements and Matrix scalar constructors (closes #21)

### DIFF
--- a/.agents/skills/license-header-adder/SKILL.md
+++ b/.agents/skills/license-header-adder/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: license-header-adder
+description: Automatically adds a license header to source files with a filename placeholder.
+---
+
+# License Header Adder Skill
+
+This skill allows you to add a consistent LGPLv3 license header to all source files in the project.
+
+## Instructions
+
+1.  **Read the Template**: Locate the license template in `resources/HEADER.txt`.
+2.  **Placeholder Replacement**: Before applying the header to a file, replace the `{{FILENAME}}` placeholder with the basename of the target file.
+3.  **Supported Files**: apply this header to:
+    - `.rs` files
+    - `.c` and `.h` files
+    - `.js` and `.ts` files
+4.  **Application Logic**:
+    - If the file already has a license header, skip it.
+    - **Exclusions**: Never apply this to files in `benchmarks/c_benchmark/src/WebARKitLib` or third-party vendor directories.
+    - Insert the header at the very top of the file.
+    - Ensure there is a blank line after the header before the original content starts.
+
+## Example Usage
+
+When applying to `core/src/lib.rs`:
+```rust
+/*
+ * lib.rs
+ * 
+ * WebARKitLib.rs - High-performance AR tracking library
+ ...
+ */
+
+use wasm_bindgen::prelude::*;
+...
+```

--- a/.agents/skills/license-header-adder/resources/HEADER.txt
+++ b/.agents/skills/license-header-adder/resources/HEADER.txt
@@ -1,0 +1,36 @@
+/*
+ *  {{FILENAME}}
+ *  purecv
+ *
+ *  This file is part of purecv - OpenCV.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+

--- a/.agents/workflows/add-license-headers.md
+++ b/.agents/workflows/add-license-headers.md
@@ -1,0 +1,17 @@
+---
+description: Apply LGPLv3 license headers to src files (.rs, .js, .ts)
+---
+
+This workflow automates the application of the project's license header to source files using the `license-header-adder` skill.
+
+1. **Identify Target Files**: Search for files with extensions `.rs`, `.js`, or `.ts` exclusively within the `src/`, `benches/` and `examples/` directory.
+   - **Exclusions**: Do not process files in `benchmarks/c_benchmark/src/WebARKitLib` or any third-party vendor directories.
+
+2. **Check for Existing Headers**: For each file, check if it already contains the license header (look for the string "purecv is free software"). If it exists, skip the file.
+
+3. **Apply the Header**:
+   - Invoke the `license-header-adder` skill.
+   - Ensure the `{{FILENAME}}` placeholder is replaced with the actual basename of the file.
+   - Insert the header at the extreme top of the file, followed by a blank line.
+
+4. **Verification**: Confirm that the headers are correctly applied and that no files were corrupted or doubled-up on headers.

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,13 @@ cpp_ref/opencv
 
 # AI
 .agents/*
+!.agents/rules/purecv.md
+!.agents/skills/
+!.agents/skills/license-header-adder/SKILL.md
+!.agents/skills/license-header-adder/resources/HEADER.txt
 !.agents/instructions.md
+!.agents/workflows/
+!.agents/workflows/add-license-headers.md
 
 # Examples
 examples/data/out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# PureCV — Claude Code Instructions
+
+## Project Mission
+Pure Rust port of OpenCV's `core` and `imgproc` modules. Memory-safe, zero-FFI,
+high-performance. See `.agents/instructions.md` for the full architectural mandate.
+
+## Architectural Rules
+
+- **Zero-FFI:** No `bindgen`, `cc`, or C++ linking. Every algorithm must be rewritten in idiomatic Rust.
+- **Memory Safety:** Use Rust's ownership model. Prefer `Vec<T>` or `Box<[T]>` for buffers. Avoid `unsafe` — if you must use it, justify why `pulp` or `std::arch` is required and why safe iterators failed.
+- **Data Layout:** Row-major contiguous memory (`Matrix<T>`) matching `cv::Mat`.
+- **Concurrency:** Use Rayon (`parallel` feature) for pixel-parallel tasks; always provide a sequential fallback.
+- **SIMD:** Use `pulp` (`simd` feature) for manual SIMD. Prefer `.chunks_exact(n)` over `.chunks(n)` for LLVM auto-vectorization.
+- **OpenCV Parity:** Match OpenCV default border types and naming (e.g. `cvt_color` not `convert_color`).
+- **Error handling:** Use `Result<T, PureCvError>` — never `panic!` in library code.
+
+## Code Quality — run in this order before every commit
+
+```bash
+cargo fmt
+cargo clippy        # fix ALL warnings
+cargo test          # all unit + doc tests must pass
+```
+
+CI rejects any PR that fails `cargo fmt --check` or `cargo clippy`.
+
+## New Files
+
+Every new Rust source file must start with the LGPL-3.0 license header.
+Template: `.agents/skills/license-header-adder/resources/HEADER.txt`
+Replace `{{FILENAME}}` with the actual filename.
+
+## Commits — Conventional Commits (mandatory)
+
+Format: `<type>(<scope>): <description>`
+
+| Type | When |
+|------|------|
+| `feat` | new feature or algorithm |
+| `fix` | bug fix |
+| `perf` | performance improvement |
+| `doc` | documentation only |
+| `refactor` | neither fix nor feature |
+| `test` | adding or fixing tests |
+| `chore` | build, deps, tooling |
+
+Preferred scopes: `(core)` `(imgproc)` `(simd)` `(wasm)` `(parallel)`
+
+## Git / PR Workflow
+
+- PRs start from and target the `dev` branch (not `main`).
+- Keep PRs focused; one feature or fix per PR.
+
+## Project Structure
+
+```
+src/core/       — Matrix<T>, Scalar, arithmetic, stats, linear algebra
+src/imgproc/    — color conversion, filtering, edge detection, threshold
+crates/wasm/    — wasm-bindgen wrappers and wasm-pack build
+benches/        — Criterion benchmarks
+.agents/        — reference docs, roadmap, skills (shared with other agents)
+```
+
+## Key Types
+
+- `Matrix<T>` — main n-channel image/matrix type
+- `Scalar<T>` — 4-channel per-pixel constant (channels beyond 4 default to `T::default()`)
+- `MatType` / `Depth` — OpenCV-style type constants (`CV_8UC3`, `CV_32FC1`, …)
+- `PureCvError` — library error type; use `Result<T, PureCvError>` everywhere
+
+## Performance Notes
+
+- SIMD + Parallel benchmarks target 1024×1024 matrices.
+- Full benchmark results: `benches/benchmark_results.md`.
+- Best speedup achieved: 22× (`sobel_3x3_f32` with Parallel + SIMD).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Unlike existing wrappers, **PureCV** is a native rewrite. It aims to provide:
 ### `purecv-core`
 - **Matrix Operations:** Multi-dimensional `Matrix<T>` with support for common arithmetic (`add`, `subtract`, `multiply`, `divide`) and bitwise logic (`bitwise_and`, `bitwise_or`, `bitwise_xor`, `bitwise_not`). Matrix and scalar variants for all operations.
 - **Factory Methods:** Intuitive initialization with `zeros`, `ones`, `eye`, and `diag`.
+- **Scalar constructors:** `Matrix::new_with_scalar` (fill all pixels from a `Scalar<T>`), `new_with_scalar_from_size`, and `new_with_scalar_typed_from_size`. `set_to` and `set_to_masked` assign a `Scalar<T>` to every pixel (optionally masked); channels beyond 4 default to `T::default()`.
+- **Scalar type:** `Scalar<T>` — a 4-channel value — now supports `Index`/`IndexMut` for channel access, `from_array`/`to_array`, `From<[T;4]>` and `From<T>` conversions, and a `map()` helper for per-channel type transforms. Arithmetic traits: per-channel `Add`/`Sub`; `Mul<T>`/`Mul<Scalar<T>>` for scaling and element-wise multiply; safe `Div<T>`/`Div<Scalar<T>>` (returns zero on divide-by-zero); `checked_div()` returning `Result` for integer types.
 - **Comparison:** `compare`, `compare_scalar`, `min`, `max`, `abs_diff`, `in_range`.
 - **Structural:** `flip`, `rotate`, `transpose`, `repeat`, `reshape`, `hconcat`, `vconcat`, `copy_make_border`, `extract_channel`, `insert_channel`.
 - **Math:** `sqrt`, `exp`, `log`, `pow`, `magnitude`, `phase`, `cart_to_polar`, `polar_to_cart`, `convert_scale_abs`.
@@ -91,10 +93,44 @@ use purecv::imgproc::{cvt_color, ColorConversionCodes};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a 3-channel matrix initialized to ones
     let mat = Matrix::<f32>::ones(480, 640, 3);
-    
+
     // Create an identity matrix
     let identity = Matrix::<f32>::eye(3, 3, 1);
-    
+
+    // --- Scalar API ---
+
+    // Build a Scalar from individual channels or a single broadcast value
+    let blue = Scalar::new(255.0f32, 0.0, 0.0, 0.0);
+    let gray = Scalar::all(128.0f32);   // all four channels = 128
+
+    // Index channels directly
+    assert_eq!(blue[0], 255.0);
+
+    // Conversions
+    let from_arr: Scalar<f32> = [1.0, 2.0, 3.0, 4.0].into();
+    let arr = from_arr.to_array();          // → [1.0, 2.0, 3.0, 4.0]
+
+    // Per-channel arithmetic
+    let a = Scalar::new(10.0f32, 20.0, 30.0, 40.0);
+    let b = Scalar::new(1.0f32,  2.0,  3.0,  4.0);
+    let sum   = a + b;                      // per-channel add
+    let diff  = a - b;                      // per-channel sub
+    let scaled = a * 2.0f32;               // broadcast multiply
+    let prod  = a * b;                      // element-wise multiply
+    let div   = a / 2.0f32;               // broadcast divide (zero-safe)
+
+    // Map channels to another type
+    let as_u8: Scalar<u8> = a.map(|x| x as u8);
+
+    // --- Matrix scalar constructors ---
+
+    // Fill an entire matrix with a constant Scalar value
+    let filled = Matrix::<f32>::new_with_scalar(480, 640, 3, blue);
+
+    // Use set_to to overwrite an existing matrix
+    let mut mat2 = Matrix::<f32>::zeros(480, 640, 3);
+    mat2.set_to(gray);
+
     println!("Matrix size: {}x{}", mat.cols, mat.rows);
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ RUSTFLAGS="-C target-cpu=native" cargo bench --features parallel
   - [x] PR 1 — SIMD infra + `arithm` kernels (`add`, `sub`, `mul`, `div`, `dot`, `magnitude`, `add_weighted`, `convert_scale_abs`, `sqrt`, `min`, `max`, `sum`).
   - [x] PR 2 — Color + Threshold SIMD: fixed-point `cvt_color_*_to_gray` kernels, `simd_threshold()` for all 5 types on `u8`/`f32`/`f64`, new `threshold` example.
   - [x] PR 3 — Derivatives SIMD: `fast_deriv_3x3` interior SIMD pass (`simd_deriv_3x3_row_f32`) achieving **22× speedup** on `sobel_3x3_f32`; new benchmarks for `sobel_3x3_f32_dx/dy` and `bilateral_filter`.
-- [ ] **Phase 3: WebAssembly** - `wasm-bindgen` wrappers, `wasm-pack` build, CI matrix with `wasm32-unknown-unknown` + `simd128`.
+- [x] **Phase 3: WebAssembly** - `wasm-bindgen` wrappers, `wasm-pack` build, CI matrix with `wasm32-unknown-unknown` + `simd128`.
 - [ ] **Phase 4: Image Processing** - Advanced filtering, convolutions, and feature detection.
 - [ ] **Visual examples** — Load real images, apply `threshold` + `cvt_color`, save PNG output (follow-up to `filters.rs`).
 

--- a/crates/wasm/pkg/README.md
+++ b/crates/wasm/pkg/README.md
@@ -1,204 +1,65 @@
-# PureCV
+# @webarkit/purecv-wasm
 
-![PureCv Banner](./assets/purecv_banner.png)
+This is the official WebAssembly binding for **PureCV**, providing high-performance, pure-Rust image processing and computer vision functions directly in the browser and Node.js.
 
-[![Rust CI](https://github.com/webarkit/purecv/actions/workflows/rust.yml/badge.svg)](https://github.com/webarkit/purecv/actions/workflows/rust.yml)
-[![Crates.io](https://img.shields.io/crates/v/purecv.svg)](https://crates.io/crates/purecv)
-[![Crates.io Downloads](https://img.shields.io/crates/d/purecv.svg)](https://crates.io/crates/purecv)
-[![GitHub Stars](https://img.shields.io/github/stars/webarkit/purecv.svg?style=social)](https://github.com/webarkit/purecv/stargazers)
-[![GitHub Forks](https://img.shields.io/github/forks/webarkit/purecv.svg?style=social)](https://github.com/webarkit/purecv/network/members)
+[![NPM version](https://img.shields.io/npm/v/@webarkit/purecv-wasm.svg)](https://www.npmjs.com/package/@webarkit/purecv-wasm)
 
-A high-performance, **pure Rust** computer vision library focusing on the `core` and `imgproc` modules of OpenCV. **PureCV** is built from the ground up to be memory-safe, thread-safe, and highly portable without the overhead of C++ FFI.
+## Dual-Build Architecture
 
-> This project is currently a **Work in Progress**. While most core and imgproc features have been implemented, the library is not yet stable, and bugs may occur. We are actively optimizing and expanding the feature set.
+This package comes heavily optimized out of the box with a **dual-build strategy**:
+- **Standard (`dist-std`)**: Provides maximum browser compatibility.
+- **SIMD (`dist-simd`)**: Delivers massive performance boosts in environments that support WebAssembly `simd128` (most modern browsers).
 
-## 🎯 Philosophy
+You can load either module depending on your runtime capabilities.
 
-Unlike existing wrappers, **PureCV** is a native rewrite. It aims to provide:
+## Installation
 
-* **Zero-FFI:** No complex linking or C++ toolchain requirements.
-* **Memory Safety:** Elimination of segmentation faults and buffer overflows via Rust's ownership model.
-* **Modern Parallelism:** Native integration with **Rayon** for effortless multi-core processing.
-* **Portable SIMD:** Optional SIMD acceleration via [`pulp`](https://crates.io/crates/pulp) — auto-detects x86 SSE/AVX, ARM NEON, and WASM `simd128` at runtime. Zero `unsafe`, zero `#[cfg(target_arch)]`.
-
-## ✨ Features
-
-### `purecv-core`
-- **Matrix Operations:** Multi-dimensional `Matrix<T>` with support for common arithmetic (`add`, `subtract`, `multiply`, `divide`) and bitwise logic (`bitwise_and`, `bitwise_or`, `bitwise_xor`, `bitwise_not`). Matrix and scalar variants for all operations.
-- **Factory Methods:** Intuitive initialization with `zeros`, `ones`, `eye`, and `diag`.
-- **Comparison:** `compare`, `compare_scalar`, `min`, `max`, `abs_diff`, `in_range`.
-- **Structural:** `flip`, `rotate`, `transpose`, `repeat`, `reshape`, `hconcat`, `vconcat`, `copy_make_border`, `extract_channel`, `insert_channel`.
-- **Math:** `sqrt`, `exp`, `log`, `pow`, `magnitude`, `phase`, `cart_to_polar`, `polar_to_cart`, `convert_scale_abs`.
-- **Stats:** `sum`, `mean`, `mean_std_dev`, `min_max_loc`, `norm`, `normalize`, `count_non_zero`, `reduce`.
-- **Linear Algebra:** `gemm`, `dot`, `cross`, `trace`, `determinant`, `invert`, `solve`, `solve_poly`, `set_identity`.
-- **Sorting:** `sort`, `sort_idx` with configurable row/column and ascending/descending flags.
-- **Clustering:** `kmeans` with random, k-means++, and user-supplied initialization strategies.
-- **Transforms:** `transform` (per-element matrix transformation), `perspective_transform` (projective / homography mapping).
-- **Random Number Generation:** `randu` (uniform distribution), `randn` (normal/Gaussian distribution), `set_rng_seed`.
-- **Channel Management:** `split`, `merge`, `mix_channels`.
-- **Utilities:** `add_weighted`, `check_range`, `absdiff`, `get_tick_count`, `get_tick_frequency`.
-- **ndarray Interop:** Optional, zero-cost conversions to/from `ndarray::Array3` via the `ndarray` feature flag.
-- **SIMD Acceleration** (`simd` feature): Trait-based dispatch via `pulp` for `f32`, `f64`, and `u8` types. Accelerated operations include `add`, `sub`, `mul`, `div`, `min`, `max`, `sqrt`, `dot`, `sum`, `add_weighted`, `convert_scale_abs`, and `magnitude`. Falls back to scalar loops at zero cost when disabled.
-
-### `purecv-imgproc`
-- **Color Conversions:** High-performance `cvt_color` supporting RGB, BGR, Gray, RGBA, BGRA and more. Up to **6.6× speedup** with Parallel + SIMD. SIMD-accelerated paths (`simd` feature) use fixed-point integer arithmetic (coefficients 77/150/29 ≈ 0.299/0.587/0.114 × 256) for all `*_to_gray` conversions — portable to x86 SSE/AVX, ARM NEON, and WASM `simd128` via `pulp`.
-- **Edge Detection:** `canny`, `sobel`, `scharr`, `laplacian`. Optimized `fast_deriv_3x3` kernel delivers up to **12× speedup** with Parallel. For `f32` inputs, the `pulp`-powered `simd_deriv_3x3_row_f32` interior kernel adds a further **1.5× boost**, reaching **22× total speedup** (28.59 ms → 1.28 ms) with Parallel + SIMD — the highest combined speedup in the project.
-- **Filtering:** `blur`, `box_filter`, `gaussian_blur`, `median_blur`, `bilateral_filter`. The bilateral filter achieves **7.1× speedup** with Parallel (1.43 s → 202 ms on 512×512); SIMD provides no additional gain due to the non-vectorizable per-pixel exponential weight computation.
-- **Thresholding:** `threshold` with all 5 OpenCV-compatible types (`BINARY`, `BINARY_INV`, `TRUNC`, `TOZERO`, `TOZERO_INV`). SIMD-accelerated fast path for `u8`, `f32`, and `f64` via the `SimdElement::simd_threshold()` trait method. Works seamlessly with `parallel` feature for row-level Rayon dispatch.
-
-## 🚀 Getting Started
-
-### Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-[dependencies]
-purecv = "0.1"
+```bash
+npm install @webarkit/purecv-wasm
 ```
 
-### Feature Flags
+## Usage Example
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `std` | ✅ | Standard library support |
-| `parallel` | ✅ | Multi-core parallelism via **Rayon** |
-| `ndarray` | ❌ | Interop with the `ndarray` crate (zero-cost views & ownership transfers) |
-| `simd` | ❌ | SIMD acceleration via [`pulp`](https://crates.io/crates/pulp) (x86 SSE/AVX, ARM NEON, WASM `simd128`) |
-| `wasm` | ❌ | WebAssembly-specific optimizations |
+```javascript
+// Example using a bundler (webpack, vite) or in Node.js
+import init, { PureCvMatrixU8, gaussianBlur } from '@webarkit/purecv-wasm/dist-std/purecv.js';
 
-To enable the `ndarray` feature:
+async function run() {
+    // Initialize WebAssembly
+    await init();
 
-```toml
-[dependencies]
-purecv = { version = "0.1", features = ["ndarray"] }
-```
+    const width = 640;
+    const height = 480;
+    const channels = 3;
 
-To enable SIMD + Parallel for maximum performance:
-
-```toml
-[dependencies]
-purecv = { version = "0.1", features = ["parallel", "simd"] }
-```
-
-### Usage Example
-
-```rust
-use purecv::core::{Matrix, Size, Scalar};
-use purecv::imgproc::{cvt_color, ColorConversionCodes};
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create a 3-channel matrix initialized to ones
-    let mat = Matrix::<f32>::ones(480, 640, 3);
+    // Create a new matrix
+    const mat = PureCvMatrixU8.create(width, height, channels);
     
-    // Create an identity matrix
-    let identity = Matrix::<f32>::eye(3, 3, 1);
-    
-    println!("Matrix size: {}x{}", mat.cols, mat.rows);
-    Ok(())
+    // Process your image data here...
+    // For example, uploading an ImageData array buffer to `mat`
+
+    // Apply a Gaussian Blur of size 5x5
+    const blurredMat = gaussianBlur(mat, 5, 5, 0.0, 0.0);
+
+    // Free memory manually!
+    mat.free();
+    blurredMat.free();
 }
+
+run();
 ```
 
-### ndarray Interoperability
+For a concrete, runnable example directly in an HTML file using `fetch`, check out the `www/` demo directory in our GitHub repository!
 
-With the `ndarray` feature enabled, you can convert between `Matrix<T>` and `ndarray::Array3<T>`:
+## Memory Management
 
-```rust
-use purecv::core::Matrix;
+Because WebAssembly runs linearly in memory and holds pointers to Rust `Vec` objects, memory allocated for matrices such as `PureCvMatrixU8` and `PureCvMatrix` are not automatically garbage collected by JavaScript. When you are done manipulating your matrix, **you must ensure you call `.free()`** to prevent memory leaks in the browser.
 
-// Matrix → ndarray (zero-cost view)
-let mat = Matrix::<f32>::ones(480, 640, 3);
-let view = mat.as_ndarray_view(); // ArrayView3<f32>, shape (480, 640, 3)
+## API coverage
 
-// Matrix → ndarray (ownership transfer)
-let mat2 = Matrix::<f32>::ones(480, 640, 3);
-let arr = mat2.into_ndarray();
+Right now we have covered a large majority of operations for `core` and `imgproc`:
 
-// ndarray → Matrix (guarantees contiguous C-order layout for SIMD/WASM)
-let mat3 = Matrix::from_ndarray(arr);
+- **Core**: Arithmetic (`add`, `subtract`, `multiply`, `absDiff` etc.), Structural (`hconcat`, `vconcat`, `flip`), Geometry, constants etc.
+- **ImgProc**: Filters (`blur`, `gaussianBlur`, `bilateralFilter`), Thresholding (`threshold`), Coloring (`cvtColor`), Edge Derivatives (`canny`, `sobel`, `laplacian`).
 
-// Also works via the From trait
-let arr2 = ndarray::Array3::<f32>::zeros((100, 100, 3));
-let mat4: Matrix<f32> = Matrix::from(arr2);
-```
-
-### Running Examples
-
-Explore the capabilities of PureCV by running the provided examples:
-
-```bash
-# Basic matrix arithmetic
-cargo run --example arithmetic
-
-# Structural operations (flip, rotate, split/merge)
-cargo run --example structural_ops
-
-# Color conversion (RGB to Grayscale)
-cargo run --example color_conversion
-
-# Thresholding — all 5 types (BINARY, BINARY_INV, TRUNC, TOZERO, TOZERO_INV)
-cargo run --example threshold
-
-# Image filters (blur, gaussian, canny, sobel, …) — requires examples/data/butterfly.jpg
-cargo run --example filters
-```
-
-## 🧪 Testing & Benchmarking
-
-### Running Tests
-PureCV uses a comprehensive suite of unit tests to ensure correctness and parity with OpenCV.
-
-```bash
-# Run all tests
-cargo test
-```
-
-### Running Benchmarks
-Performance is a core focus. Benchmarks are available for `arithm`, `imgproc`, and `structural` modules across four configurations:
-
-```bash
-# Standard (sequential, no SIMD)
-cargo bench --no-default-features
-
-# SIMD Only (sequential + auto-vectorization)
-RUSTFLAGS="-C target-cpu=native" cargo bench --no-default-features
-
-# Parallel (Rayon multi-threading)
-cargo bench --features parallel
-
-# Parallel + SIMD (maximum throughput)
-RUSTFLAGS="-C target-cpu=native" cargo bench --features parallel
-```
-
-#### Key Performance Highlights (1024×1024 matrices, *updated 2026-03-17*)
-
-| Operation | Standard | Parallel + SIMD | Speedup |
-|-----------|----------|-----------------|---------|
-| `cvt_color_rgb2gray` | 2.66 ms | **404 µs** | 6.6× |
-| `sobel_3x3` (generic) | 22.79 ms | **1.87 ms** | 12× |
-| `sobel_3x3_f32_dx` ★ | 28.59 ms | **1.28 ms** | **22×** |
-| `sobel_3x3_f32_dy` ★ | 26.24 ms | **1.27 ms** | **21×** |
-| `bilateral_filter` (512×512) | 1.43 s | **202 ms** | 7.1× |
-| `laplacian_3x3` | 45.91 ms | **4.44 ms** | 10.4× |
-| `dot` | 997 µs | **157 µs** | 6.4× |
-| `gemm_256×256` | 15.71 ms | **4.40 ms** | 3.7× |
-| `canny` | 57.61 ms | **12.54 ms** | 4.6× |
-
-> ★ Uses non-zero sinusoidal data to exercise the `simd_deriv_3x3_row_f32` SIMD kernel. Best combined speedup in the project.
->
-> Full results in [`benches/benchmark_results.md`](./benches/benchmark_results.md)
-
-## 🗺 Roadmap
-
-- [x] **Phase 1: Core Foundation** - Matrix types, arithmetic, geometric utilities, and basic structural transforms.
-- [x] **Phase 2: Performance** - SIMD acceleration via `pulp`, Rayon parallelism, and Criterion benchmarking across 32 operations.
-  - [x] PR 1 — SIMD infra + `arithm` kernels (`add`, `sub`, `mul`, `div`, `dot`, `magnitude`, `add_weighted`, `convert_scale_abs`, `sqrt`, `min`, `max`, `sum`).
-  - [x] PR 2 — Color + Threshold SIMD: fixed-point `cvt_color_*_to_gray` kernels, `simd_threshold()` for all 5 types on `u8`/`f32`/`f64`, new `threshold` example.
-  - [x] PR 3 — Derivatives SIMD: `fast_deriv_3x3` interior SIMD pass (`simd_deriv_3x3_row_f32`) achieving **22× speedup** on `sobel_3x3_f32`; new benchmarks for `sobel_3x3_f32_dx/dy` and `bilateral_filter`.
-- [ ] **Phase 3: WebAssembly** - `wasm-bindgen` wrappers, `wasm-pack` build, CI matrix with `wasm32-unknown-unknown` + `simd128`.
-- [ ] **Phase 4: Image Processing** - Advanced filtering, convolutions, and feature detection.
-- [ ] **Visual examples** — Load real images, apply `threshold` + `cvt_color`, save PNG output (follow-up to `filters.rs`).
-
-## 📄 License
-
-This project is licensed under the LGPL-3.0 License.
+Note: To interface between JavaScript Typed Arrays and `purecv-wasm`, please use the available getter functions (`.data()`) which directly retrieve a Float32Array or Uint8Array view into WASM memory.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -38,9 +38,9 @@ use wasm_bindgen::prelude::*;
 
 use purecv::core::arithm;
 use purecv::core::dynamic::{DynamicData, DynamicMatrix};
-use purecv::core::matrix::MatType;
+use purecv::core::matrix::{Depth, MatType};
 use purecv::core::structural;
-use purecv::core::types::{BorderTypes, Point2i, Size2i};
+use purecv::core::types::{BorderTypes, Point2i, Scalar as CoreScalar, Size2i};
 use purecv::core::Matrix;
 use purecv::imgproc::color::{cvt_color, ColorConversionCode};
 use purecv::imgproc::derivatives;
@@ -348,6 +348,237 @@ impl Mat {
             .convert_to(depth)
             .map_err(|e| JsError::new(&format!("{e}")))?;
         Ok(Mat { inner: dm })
+    }
+
+    // -- Scalar constructors / fill -----------------------------------------
+
+    /// Creates a new Mat with every pixel set to the given `Scalar`.
+    ///
+    /// Channel values in `s` are cast to the element depth encoded in `mat_type`.
+    ///
+    /// ```js
+    /// // 480×640 BGR u8 image filled with blue (255, 0, 0)
+    /// const blue = new Scalar(255, 0, 0, 0);
+    /// const img  = Mat.newWithScalar(480, 640, CV_8UC3(), blue);
+    /// ```
+    #[wasm_bindgen(js_name = "newWithScalar")]
+    pub fn new_with_scalar(
+        rows: usize,
+        cols: usize,
+        mat_type: i32,
+        s: &Scalar,
+    ) -> Result<Mat, JsError> {
+        let mt = MatType(mat_type);
+        let ch = mt.channels();
+        let data = match mt.depth() {
+            Depth::CV_8U => DynamicData::U8(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0 as u8, s.v1 as u8, s.v2 as u8, s.v3 as u8),
+            )),
+            Depth::CV_8S => DynamicData::I8(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0 as i8, s.v1 as i8, s.v2 as i8, s.v3 as i8),
+            )),
+            Depth::CV_16U => DynamicData::U16(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0 as u16, s.v1 as u16, s.v2 as u16, s.v3 as u16),
+            )),
+            Depth::CV_16S => DynamicData::I16(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0 as i16, s.v1 as i16, s.v2 as i16, s.v3 as i16),
+            )),
+            Depth::CV_32S => DynamicData::I32(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0 as i32, s.v1 as i32, s.v2 as i32, s.v3 as i32),
+            )),
+            Depth::CV_32F => DynamicData::F32(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0 as f32, s.v1 as f32, s.v2 as f32, s.v3 as f32),
+            )),
+            Depth::CV_64F => DynamicData::F64(Matrix::new_with_scalar(
+                rows,
+                cols,
+                ch,
+                CoreScalar::new(s.v0, s.v1, s.v2, s.v3),
+            )),
+            Depth::CV_16F => return Err(JsError::new("CV_16F is not yet supported")),
+        };
+        Ok(Mat {
+            inner: DynamicMatrix { data },
+        })
+    }
+
+    /// Fills every pixel of this Mat with the given `Scalar`.
+    ///
+    /// Channel values are cast to the element depth of this Mat.
+    ///
+    /// ```js
+    /// const gray = new Scalar(128, 128, 128, 255);
+    /// mat.setTo(gray);
+    /// ```
+    #[wasm_bindgen(js_name = "setTo")]
+    pub fn set_to(&mut self, s: &Scalar) {
+        match &mut self.inner.data {
+            DynamicData::U8(m) => m.set_to(CoreScalar::new(
+                s.v0 as u8, s.v1 as u8, s.v2 as u8, s.v3 as u8,
+            )),
+            DynamicData::I8(m) => m.set_to(CoreScalar::new(
+                s.v0 as i8, s.v1 as i8, s.v2 as i8, s.v3 as i8,
+            )),
+            DynamicData::U16(m) => m.set_to(CoreScalar::new(
+                s.v0 as u16,
+                s.v1 as u16,
+                s.v2 as u16,
+                s.v3 as u16,
+            )),
+            DynamicData::I16(m) => m.set_to(CoreScalar::new(
+                s.v0 as i16,
+                s.v1 as i16,
+                s.v2 as i16,
+                s.v3 as i16,
+            )),
+            DynamicData::I32(m) => m.set_to(CoreScalar::new(
+                s.v0 as i32,
+                s.v1 as i32,
+                s.v2 as i32,
+                s.v3 as i32,
+            )),
+            DynamicData::F32(m) => m.set_to(CoreScalar::new(
+                s.v0 as f32,
+                s.v1 as f32,
+                s.v2 as f32,
+                s.v3 as f32,
+            )),
+            DynamicData::F64(m) => m.set_to(CoreScalar::new(s.v0, s.v1, s.v2, s.v3)),
+        }
+    }
+
+    /// Fills pixels with the given `Scalar` where `mask` is non-zero.
+    ///
+    /// `mask` must be a single-channel `u8` Mat with the same dimensions as `self`.
+    ///
+    /// ```js
+    /// const white = new Scalar(255, 255, 255, 255);
+    /// mat.setToMasked(white, mask);  // only pixels where mask != 0 are filled
+    /// ```
+    #[wasm_bindgen(js_name = "setToMasked")]
+    pub fn set_to_masked(&mut self, s: &Scalar, mask: &Mat) -> Result<(), JsError> {
+        let mask_m = require_u8(mask, "setToMasked")?;
+        match &mut self.inner.data {
+            DynamicData::U8(m) => m
+                .set_to_masked(
+                    CoreScalar::new(s.v0 as u8, s.v1 as u8, s.v2 as u8, s.v3 as u8),
+                    mask_m,
+                )
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+            DynamicData::I8(m) => m
+                .set_to_masked(
+                    CoreScalar::new(s.v0 as i8, s.v1 as i8, s.v2 as i8, s.v3 as i8),
+                    mask_m,
+                )
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+            DynamicData::U16(m) => m
+                .set_to_masked(
+                    CoreScalar::new(s.v0 as u16, s.v1 as u16, s.v2 as u16, s.v3 as u16),
+                    mask_m,
+                )
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+            DynamicData::I16(m) => m
+                .set_to_masked(
+                    CoreScalar::new(s.v0 as i16, s.v1 as i16, s.v2 as i16, s.v3 as i16),
+                    mask_m,
+                )
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+            DynamicData::I32(m) => m
+                .set_to_masked(
+                    CoreScalar::new(s.v0 as i32, s.v1 as i32, s.v2 as i32, s.v3 as i32),
+                    mask_m,
+                )
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+            DynamicData::F32(m) => m
+                .set_to_masked(
+                    CoreScalar::new(s.v0 as f32, s.v1 as f32, s.v2 as f32, s.v3 as f32),
+                    mask_m,
+                )
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+            DynamicData::F64(m) => m
+                .set_to_masked(CoreScalar::new(s.v0, s.v1, s.v2, s.v3), mask_m)
+                .map_err(|e| JsError::new(&format!("{e}")))?,
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Scalar — 4-channel value type
+// ---------------------------------------------------------------------------
+
+/// A 4-channel value for initialising or filling matrices.
+///
+/// Channel values are `f64` and are cast to the element depth of the target
+/// `Mat` when passed to `newWithScalar`, `setTo`, or `setToMasked`.
+///
+/// ```js
+/// const blue  = new Scalar(255, 0, 0, 0);      // BGR blue
+/// const gray  = new Scalar(128, 128, 128, 255); // RGBA mid-gray
+/// const white = Scalar.all(255);                // broadcast
+/// ```
+#[wasm_bindgen(js_name = "Scalar")]
+pub struct Scalar {
+    pub v0: f64,
+    pub v1: f64,
+    pub v2: f64,
+    pub v3: f64,
+}
+
+#[wasm_bindgen(js_name = "Scalar")]
+impl Scalar {
+    /// Creates a Scalar from four channel values.
+    #[wasm_bindgen(constructor)]
+    pub fn new(v0: f64, v1: f64, v2: f64, v3: f64) -> Scalar {
+        Scalar { v0, v1, v2, v3 }
+    }
+
+    /// Creates a Scalar with the same value broadcast to all four channels.
+    ///
+    /// ```js
+    /// const white = Scalar.all(255); // [255, 255, 255, 255]
+    /// ```
+    pub fn all(v: f64) -> Scalar {
+        Scalar {
+            v0: v,
+            v1: v,
+            v2: v,
+            v3: v,
+        }
+    }
+
+    /// Creates a Scalar with `v` in channel 0 and zero in channels 1–3.
+    /// Mirrors OpenCV's `cv::Scalar(v)`.
+    ///
+    /// ```js
+    /// const luma = Scalar.fromValue(128); // [128, 0, 0, 0]
+    /// ```
+    #[wasm_bindgen(js_name = "fromValue")]
+    pub fn from_value(v: f64) -> Scalar {
+        Scalar {
+            v0: v,
+            v1: 0.0,
+            v2: 0.0,
+            v3: 0.0,
+        }
     }
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -37,6 +37,7 @@
 use wasm_bindgen::prelude::*;
 
 use purecv::core::arithm;
+use purecv::core::dynamic::{DynamicData, DynamicMatrix};
 use purecv::core::structural;
 use purecv::core::types::{BorderTypes, Point2i, Size2i};
 use purecv::core::Matrix;
@@ -78,46 +79,94 @@ pub fn init_purecv() {
 }
 
 // ---------------------------------------------------------------------------
-//  PureCvMatrixF32 — opaque wrapper around Matrix<f32>
+//  Mat — unified opaque wrapper around DynamicMatrix
 // ---------------------------------------------------------------------------
 
-/// An opaque wrapper around `Matrix<f32>`.
+/// An opaque wrapper around `DynamicMatrix`, exposed as `Mat` in JavaScript.
 ///
-/// For the browser, `f32` is the natural numeric type and a good middle
-/// ground between precision and performance for image‑processing operations.
-/// Data flows JS → WASM as `Float32Array`, gets processed, and comes back
-/// the same way.
-#[wasm_bindgen]
-pub struct PureCvMatrixF32 {
-    inner: Matrix<f32>,
+/// This is the single matrix type used across the entire WASM API.
+/// The element depth (`u8`, `f32`, `f64`, etc.) is selected at construction
+/// time and can be queried or converted at runtime.
+#[wasm_bindgen(js_name = "Mat")]
+pub struct Mat {
+    inner: DynamicMatrix,
 }
 
-#[wasm_bindgen]
-impl PureCvMatrixF32 {
+/// Internal helper: require f32 depth, return `&Matrix<f32>` or a JsError.
+fn require_f32<'a>(mat: &'a Mat, op_name: &str) -> Result<&'a Matrix<f32>, JsError> {
+    mat.inner.as_matrix_f32().ok_or_else(|| {
+        JsError::new(&format!(
+            "{op_name} requires f32 depth, but Mat has depth '{}'",
+            mat.inner.depth_name()
+        ))
+    })
+}
+
+/// Internal helper: require u8 depth, return `&Matrix<u8>` or a JsError.
+fn require_u8<'a>(mat: &'a Mat, op_name: &str) -> Result<&'a Matrix<u8>, JsError> {
+    mat.inner.as_matrix_u8().ok_or_else(|| {
+        JsError::new(&format!(
+            "{op_name} requires u8 depth, but Mat has depth '{}'",
+            mat.inner.depth_name()
+        ))
+    })
+}
+
+#[wasm_bindgen(js_name = "Mat")]
+impl Mat {
     // -- Constructors -------------------------------------------------------
 
-    /// Creates a new zero-filled matrix.
+    /// Creates a new zero-filled matrix with the given depth.
     ///
     /// * `rows`     – Number of rows (height).
     /// * `cols`     – Number of columns (width).
     /// * `channels` – Number of channels (e.g. 1 for gray, 3 for RGB, 4 for RGBA).
+    /// * `depth`    – Element type: `"u8"`, `"i8"`, `"u16"`, `"i16"`, `"i32"`, `"f32"`, `"f64"`.
+    ///               Defaults to `"f32"` if omitted or empty.
     #[wasm_bindgen(constructor)]
-    pub fn new(rows: usize, cols: usize, channels: usize) -> PureCvMatrixF32 {
-        PureCvMatrixF32 {
-            inner: Matrix::<f32>::new(rows, cols, channels),
-        }
-    }
-
-    /// Creates a matrix from a `Float32Array`.
-    ///
-    /// The array length **must** equal `rows × cols × channels`.
-    #[wasm_bindgen(js_name = "fromData")]
-    pub fn from_data(
+    pub fn new(
         rows: usize,
         cols: usize,
         channels: usize,
-        data: &[f32],
-    ) -> Result<PureCvMatrixF32, JsError> {
+        depth: Option<String>,
+    ) -> Result<Mat, JsError> {
+        let depth_str = depth.unwrap_or_else(|| "f32".to_string());
+        let dm = match depth_str.as_str() {
+            "u8" => DynamicMatrix::new_u8(rows, cols, channels, vec![0u8; rows * cols * channels]),
+            "i8" => DynamicMatrix::new_i8(rows, cols, channels, vec![0i8; rows * cols * channels]),
+            "u16" => {
+                DynamicMatrix::new_u16(rows, cols, channels, vec![0u16; rows * cols * channels])
+            }
+            "i16" => {
+                DynamicMatrix::new_i16(rows, cols, channels, vec![0i16; rows * cols * channels])
+            }
+            "i32" => {
+                DynamicMatrix::new_i32(rows, cols, channels, vec![0i32; rows * cols * channels])
+            }
+            "f32" => {
+                DynamicMatrix::new_f32(rows, cols, channels, vec![0f32; rows * cols * channels])
+            }
+            "f64" => {
+                DynamicMatrix::new_f64(rows, cols, channels, vec![0f64; rows * cols * channels])
+            }
+            other => {
+                return Err(JsError::new(&format!(
+                    "Unknown depth '{other}'. Use one of: u8, i8, u16, i16, i32, f32, f64"
+                )));
+            }
+        };
+        dm.map(|d| Mat { inner: d })
+            .map_err(|e| JsError::new(&format!("{e}")))
+    }
+
+    /// Creates a Mat from a `Uint8Array`.
+    #[wasm_bindgen(js_name = "fromU8Data")]
+    pub fn from_u8_data(
+        rows: usize,
+        cols: usize,
+        channels: usize,
+        data: &[u8],
+    ) -> Result<Mat, JsError> {
         let expected = rows * cols * channels;
         if data.len() != expected {
             return Err(JsError::new(&format!(
@@ -129,9 +178,57 @@ impl PureCvMatrixF32 {
                 expected
             )));
         }
-        let mut mat = Matrix::<f32>::new(rows, cols, channels);
-        mat.data.copy_from_slice(data);
-        Ok(PureCvMatrixF32 { inner: mat })
+        let dm = DynamicMatrix::new_u8(rows, cols, channels, data.to_vec())
+            .map_err(|e| JsError::new(&format!("{e}")))?;
+        Ok(Mat { inner: dm })
+    }
+
+    /// Creates a Mat from a `Float32Array`.
+    #[wasm_bindgen(js_name = "fromF32Data")]
+    pub fn from_f32_data(
+        rows: usize,
+        cols: usize,
+        channels: usize,
+        data: &[f32],
+    ) -> Result<Mat, JsError> {
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(JsError::new(&format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
+        let dm = DynamicMatrix::new_f32(rows, cols, channels, data.to_vec())
+            .map_err(|e| JsError::new(&format!("{e}")))?;
+        Ok(Mat { inner: dm })
+    }
+
+    /// Creates a Mat from a `Float64Array`.
+    #[wasm_bindgen(js_name = "fromF64Data")]
+    pub fn from_f64_data(
+        rows: usize,
+        cols: usize,
+        channels: usize,
+        data: &[f64],
+    ) -> Result<Mat, JsError> {
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(JsError::new(&format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
+        let dm = DynamicMatrix::new_f64(rows, cols, channels, data.to_vec())
+            .map_err(|e| JsError::new(&format!("{e}")))?;
+        Ok(Mat { inner: dm })
     }
 
     // -- Accessors ----------------------------------------------------------
@@ -139,259 +236,314 @@ impl PureCvMatrixF32 {
     /// Returns the number of rows (height).
     #[wasm_bindgen(getter)]
     pub fn rows(&self) -> usize {
-        self.inner.rows
+        self.inner.rows()
     }
 
     /// Returns the number of columns (width).
     #[wasm_bindgen(getter)]
     pub fn cols(&self) -> usize {
-        self.inner.cols
+        self.inner.cols()
     }
 
     /// Returns the number of channels.
     #[wasm_bindgen(getter)]
     pub fn channels(&self) -> usize {
-        self.inner.channels
+        self.inner.channels()
     }
 
     /// Returns the total number of elements (rows × cols × channels).
     #[wasm_bindgen(getter, js_name = "length")]
     pub fn length(&self) -> usize {
-        self.inner.data.len()
+        self.inner.total()
+    }
+
+    /// Returns the element depth as a string (e.g. `"u8"`, `"f32"`).
+    #[wasm_bindgen(getter)]
+    pub fn depth(&self) -> String {
+        self.inner.depth_name().to_string()
+    }
+
+    // -- Data access --------------------------------------------------------
+
+    /// Returns a copy of the underlying data as a `Uint8Array`.
+    /// Errors if this Mat is not of depth `u8`.
+    #[wasm_bindgen(js_name = "dataU8")]
+    pub fn data_u8(&self) -> Result<Vec<u8>, JsError> {
+        self.inner
+            .data_u8()
+            .map(|s| s.to_vec())
+            .ok_or_else(|| {
+                JsError::new(&format!(
+                    "dataU8() requires u8 depth, but Mat has depth '{}'",
+                    self.inner.depth_name()
+                ))
+            })
     }
 
     /// Returns a copy of the underlying data as a `Float32Array`.
-    #[wasm_bindgen(js_name = "data")]
-    pub fn data(&self) -> Vec<f32> {
-        self.inner.data.clone()
+    /// Errors if this Mat is not of depth `f32`.
+    #[wasm_bindgen(js_name = "dataF32")]
+    pub fn data_f32(&self) -> Result<Vec<f32>, JsError> {
+        self.inner
+            .data_f32()
+            .map(|s| s.to_vec())
+            .ok_or_else(|| {
+                JsError::new(&format!(
+                    "dataF32() requires f32 depth, but Mat has depth '{}'",
+                    self.inner.depth_name()
+                ))
+            })
     }
 
-    /// Sets the underlying data from a `Float32Array`.
-    #[wasm_bindgen(js_name = "setData")]
-    pub fn set_data(&mut self, data: &[f32]) -> Result<(), JsError> {
-        if data.len() != self.inner.data.len() {
-            return Err(JsError::new(&format!(
-                "Data length {} does not match matrix length {}",
-                data.len(),
-                self.inner.data.len()
-            )));
+    /// Returns a copy of the underlying data as a `Float64Array`.
+    /// Errors if this Mat is not of depth `f64`.
+    #[wasm_bindgen(js_name = "dataF64")]
+    pub fn data_f64(&self) -> Result<Vec<f64>, JsError> {
+        self.inner
+            .data_f64()
+            .map(|s| s.to_vec())
+            .ok_or_else(|| {
+                JsError::new(&format!(
+                    "dataF64() requires f64 depth, but Mat has depth '{}'",
+                    self.inner.depth_name()
+                ))
+            })
+    }
+
+    /// Sets the underlying data from a `Uint8Array`. Errors if depth is not `u8`.
+    #[wasm_bindgen(js_name = "setDataU8")]
+    pub fn set_data_u8(&mut self, data: &[u8]) -> Result<(), JsError> {
+        match &mut self.inner.data {
+            DynamicData::U8(m) => {
+                if data.len() != m.data.len() {
+                    return Err(JsError::new(&format!(
+                        "Data length {} does not match matrix length {}",
+                        data.len(),
+                        m.data.len()
+                    )));
+                }
+                m.data.copy_from_slice(data);
+                Ok(())
+            }
+            _ => Err(JsError::new(&format!(
+                "setDataU8() requires u8 depth, but Mat has depth '{}'",
+                self.inner.depth_name()
+            ))),
         }
-        self.inner.data.copy_from_slice(data);
-        Ok(())
     }
 
-    /// Returns the value at (row, col, channel).
+    /// Sets the underlying data from a `Float32Array`. Errors if depth is not `f32`.
+    #[wasm_bindgen(js_name = "setDataF32")]
+    pub fn set_data_f32(&mut self, data: &[f32]) -> Result<(), JsError> {
+        match &mut self.inner.data {
+            DynamicData::F32(m) => {
+                if data.len() != m.data.len() {
+                    return Err(JsError::new(&format!(
+                        "Data length {} does not match matrix length {}",
+                        data.len(),
+                        m.data.len()
+                    )));
+                }
+                m.data.copy_from_slice(data);
+                Ok(())
+            }
+            _ => Err(JsError::new(&format!(
+                "setDataF32() requires f32 depth, but Mat has depth '{}'",
+                self.inner.depth_name()
+            ))),
+        }
+    }
+
+    /// Sets the underlying data from a `Float64Array`. Errors if depth is not `f64`.
+    #[wasm_bindgen(js_name = "setDataF64")]
+    pub fn set_data_f64(&mut self, data: &[f64]) -> Result<(), JsError> {
+        match &mut self.inner.data {
+            DynamicData::F64(m) => {
+                if data.len() != m.data.len() {
+                    return Err(JsError::new(&format!(
+                        "Data length {} does not match matrix length {}",
+                        data.len(),
+                        m.data.len()
+                    )));
+                }
+                m.data.copy_from_slice(data);
+                Ok(())
+            }
+            _ => Err(JsError::new(&format!(
+                "setDataF64() requires f64 depth, but Mat has depth '{}'",
+                self.inner.depth_name()
+            ))),
+        }
+    }
+
+    /// Returns the value at (row, col, channel) cast to `f64`.
+    /// Returns `undefined` if the coordinates are out of bounds.
     #[wasm_bindgen(js_name = "at")]
-    pub fn at(&self, row: i32, col: i32, channel: usize) -> Option<f32> {
-        self.inner.at(row, col, channel).copied()
+    pub fn at(&self, row: i32, col: i32, channel: usize) -> Option<f64> {
+        self.inner.at_f64(row, col, channel)
+    }
+
+    // -- Type conversion ----------------------------------------------------
+
+    /// Converts this Mat to a new Mat with a different element depth.
+    ///
+    /// * `depth` – Target depth: `"u8"`, `"i8"`, `"u16"`, `"i16"`, `"i32"`, `"f32"`, `"f64"`.
+    #[wasm_bindgen(js_name = "convertTo")]
+    pub fn convert_to(&self, depth: &str) -> Result<Mat, JsError> {
+        let dm = self
+            .inner
+            .convert_to(depth)
+            .map_err(|e| JsError::new(&format!("{e}")))?;
+        Ok(Mat { inner: dm })
     }
 }
 
 // ---------------------------------------------------------------------------
-//  PureCvMatrixU8 — opaque wrapper around Matrix<u8>
-// ---------------------------------------------------------------------------
-
-/// An opaque wrapper around `Matrix<u8>`.
-///
-/// Used for operations that operate on or produce 8-bit images: colour
-/// conversions, Canny edge detection, thresholding of byte images, etc.
-/// Data flows JS → WASM as `Uint8Array` / `Uint8ClampedArray`.
-#[wasm_bindgen]
-pub struct PureCvMatrixU8 {
-    inner: Matrix<u8>,
-}
-
-#[wasm_bindgen]
-impl PureCvMatrixU8 {
-    // -- Constructors -------------------------------------------------------
-
-    /// Creates a new zero-filled u8 matrix.
-    #[wasm_bindgen(constructor)]
-    pub fn new(rows: usize, cols: usize, channels: usize) -> PureCvMatrixU8 {
-        PureCvMatrixU8 {
-            inner: Matrix::<u8>::new(rows, cols, channels),
-        }
-    }
-
-    /// Creates a u8 matrix from a `Uint8Array`.
-    #[wasm_bindgen(js_name = "fromData")]
-    pub fn from_data(
-        rows: usize,
-        cols: usize,
-        channels: usize,
-        data: &[u8],
-    ) -> Result<PureCvMatrixU8, JsError> {
-        let expected = rows * cols * channels;
-        if data.len() != expected {
-            return Err(JsError::new(&format!(
-                "Data length {} does not match {}×{}×{} = {}",
-                data.len(),
-                rows,
-                cols,
-                channels,
-                expected
-            )));
-        }
-        let mut mat = Matrix::<u8>::new(rows, cols, channels);
-        mat.data.copy_from_slice(data);
-        Ok(PureCvMatrixU8 { inner: mat })
-    }
-
-    // -- Accessors ----------------------------------------------------------
-
-    #[wasm_bindgen(getter)]
-    pub fn rows(&self) -> usize {
-        self.inner.rows
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn cols(&self) -> usize {
-        self.inner.cols
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn channels(&self) -> usize {
-        self.inner.channels
-    }
-
-    #[wasm_bindgen(getter, js_name = "length")]
-    pub fn length(&self) -> usize {
-        self.inner.data.len()
-    }
-
-    /// Returns a copy of the underlying data as a `Uint8Array`.
-    #[wasm_bindgen(js_name = "data")]
-    pub fn data(&self) -> Vec<u8> {
-        self.inner.data.clone()
-    }
-
-    /// Sets the underlying data from a `Uint8Array`.
-    #[wasm_bindgen(js_name = "setData")]
-    pub fn set_data(&mut self, data: &[u8]) -> Result<(), JsError> {
-        if data.len() != self.inner.data.len() {
-            return Err(JsError::new(&format!(
-                "Data length {} does not match matrix length {}",
-                data.len(),
-                self.inner.data.len()
-            )));
-        }
-        self.inner.data.copy_from_slice(data);
-        Ok(())
-    }
-
-    /// Returns the value at (row, col, channel).
-    #[wasm_bindgen(js_name = "at")]
-    pub fn at(&self, row: i32, col: i32, channel: usize) -> Option<u8> {
-        self.inner.at(row, col, channel).copied()
-    }
-}
-
-// ---------------------------------------------------------------------------
-//  Type conversion helpers
-// ---------------------------------------------------------------------------
-
-/// Converts a `PureCvMatrixU8` to a `PureCvMatrixF32` (u8 → f32).
-#[wasm_bindgen(js_name = "convertU8ToF32")]
-pub fn convert_u8_to_f32(src: &PureCvMatrixU8) -> Result<PureCvMatrixF32, JsError> {
-    let result = src
-        .inner
-        .convert_to::<f32>()
-        .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
-}
-
-/// Converts a `PureCvMatrixF32` to a `PureCvMatrixU8` (f32 → u8, values clamped to 0–255).
-#[wasm_bindgen(js_name = "convertF32ToU8")]
-pub fn convert_f32_to_u8(src: &PureCvMatrixF32) -> Result<PureCvMatrixU8, JsError> {
-    let result = src
-        .inner
-        .convert_to::<u8>()
-        .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixU8 { inner: result })
-}
-
-// ---------------------------------------------------------------------------
-//  Arithmetic operations (f32)
+//  Arithmetic operations (require f32 depth)
 // ---------------------------------------------------------------------------
 
 /// Per-element addition: `dst = a + b`.
 #[wasm_bindgen(js_name = "add")]
-pub fn add(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::add(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn add(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "add")?;
+    let mb = require_f32(b, "add")?;
+    let result = arithm::add(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Per-element subtraction: `dst = a - b`.
 #[wasm_bindgen(js_name = "subtract")]
-pub fn subtract(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::subtract(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn subtract(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "subtract")?;
+    let mb = require_f32(b, "subtract")?;
+    let result = arithm::subtract(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Per-element multiplication: `dst = a * b`.
 #[wasm_bindgen(js_name = "multiply")]
-pub fn multiply(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::multiply(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn multiply(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "multiply")?;
+    let mb = require_f32(b, "multiply")?;
+    let result = arithm::multiply(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Per-element division: `dst = a / b`.
 #[wasm_bindgen(js_name = "divide")]
-pub fn divide(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::divide(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn divide(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "divide")?;
+    let mb = require_f32(b, "divide")?;
+    let result = arithm::divide(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Per-element absolute difference: `dst = |a - b|`.
 #[wasm_bindgen(js_name = "absDiff")]
-pub fn abs_diff(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::abs_diff(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn abs_diff(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "absDiff")?;
+    let mb = require_f32(b, "absDiff")?;
+    let result = arithm::abs_diff(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Per-element minimum: `dst(i) = min(a(i), b(i))`.
 #[wasm_bindgen(js_name = "min")]
-pub fn min(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::min(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn min(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "min")?;
+    let mb = require_f32(b, "min")?;
+    let result = arithm::min(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Per-element maximum: `dst(i) = max(a(i), b(i))`.
 #[wasm_bindgen(js_name = "max")]
-pub fn max(a: &PureCvMatrixF32, b: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = arithm::max(&a.inner, &b.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn max(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
+    let ma = require_f32(a, "max")?;
+    let mb = require_f32(b, "max")?;
+    let result = arithm::max(ma, mb).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------
-//  Structural operations (f32)
+//  Structural operations (dispatch across all depths)
 // ---------------------------------------------------------------------------
 
 /// Flips a matrix around vertical (0), horizontal (1), or both axes (-1).
 #[wasm_bindgen(js_name = "flip")]
-pub fn flip(src: &PureCvMatrixF32, flip_code: i32) -> Result<PureCvMatrixF32, JsError> {
-    let result =
-        structural::flip(&src.inner, flip_code).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn flip(src: &Mat, flip_code: i32) -> Result<Mat, JsError> {
+    let data = match &src.inner.data {
+        DynamicData::U8(m) => DynamicData::U8(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I8(m) => DynamicData::I8(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::U16(m) => DynamicData::U16(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I16(m) => DynamicData::I16(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I32(m) => DynamicData::I32(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::F32(m) => DynamicData::F32(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::F64(m) => DynamicData::F64(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+    };
+    Ok(Mat { inner: DynamicMatrix { data } })
 }
 
 /// Transposes a matrix (swaps rows and columns).
 #[wasm_bindgen(js_name = "transpose")]
-pub fn transpose(src: &PureCvMatrixF32) -> Result<PureCvMatrixF32, JsError> {
-    let result = structural::transpose(&src.inner).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn transpose(src: &Mat) -> Result<Mat, JsError> {
+    let data = match &src.inner.data {
+        DynamicData::U8(m) => DynamicData::U8(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I8(m) => DynamicData::I8(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::U16(m) => DynamicData::U16(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I16(m) => DynamicData::I16(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I32(m) => DynamicData::I32(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::F32(m) => DynamicData::F32(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::F64(m) => DynamicData::F64(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+    };
+    Ok(Mat { inner: DynamicMatrix { data } })
 }
 
 /// Rotates a matrix: 0 = 90° CW, 1 = 180°, 2 = 90° CCW.
 #[wasm_bindgen(js_name = "rotate")]
-pub fn rotate(src: &PureCvMatrixF32, rotate_code: i32) -> Result<PureCvMatrixF32, JsError> {
-    let result =
-        structural::rotate(&src.inner, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+pub fn rotate(src: &Mat, rotate_code: i32) -> Result<Mat, JsError> {
+    let data = match &src.inner.data {
+        DynamicData::U8(m) => DynamicData::U8(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I8(m) => DynamicData::I8(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::U16(m) => DynamicData::U16(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I16(m) => DynamicData::I16(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::I32(m) => DynamicData::I32(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::F32(m) => DynamicData::F32(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::F64(m) => DynamicData::F64(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+    };
+    Ok(Mat { inner: DynamicMatrix { data } })
 }
 
 // ---------------------------------------------------------------------------
-//  Color conversion (u8)
+//  Color conversion (requires u8 depth)
 // ---------------------------------------------------------------------------
 
 /// Helper to convert a JS integer into a `ColorConversionCode`.
@@ -417,14 +569,19 @@ fn color_code_from_i32(code: i32) -> Result<ColorConversionCode, JsError> {
 ///   0 = BGR2GRAY, 1 = RGB2GRAY, 2 = BGRA2GRAY, 3 = RGBA2GRAY,
 ///   4 = GRAY2RGB, 5 = GRAY2BGR, 6 = GRAY2RGBA, 7 = GRAY2BGRA.
 #[wasm_bindgen(js_name = "cvtColor")]
-pub fn convert_color(src: &PureCvMatrixU8, code: i32) -> Result<PureCvMatrixU8, JsError> {
+pub fn convert_color(src: &Mat, code: i32) -> Result<Mat, JsError> {
+    let m = require_u8(src, "cvtColor")?;
     let cc = color_code_from_i32(code)?;
-    let result = cvt_color(&src.inner, cc).map_err(|e| JsError::new(e))?;
-    Ok(PureCvMatrixU8 { inner: result })
+    let result = cvt_color(m, cc).map_err(|e| JsError::new(e))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::U8(result),
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------
-//  Threshold (f32)
+//  Threshold (requires f32 depth)
 // ---------------------------------------------------------------------------
 
 /// Helper to convert a JS integer into a `ThresholdTypes`.
@@ -444,7 +601,7 @@ fn thresh_type_from_i32(t: i32) -> Result<ThresholdTypes, JsError> {
 #[wasm_bindgen]
 pub struct ThresholdResult {
     thresh_val: f64,
-    matrix: PureCvMatrixF32,
+    matrix: Mat,
 }
 
 #[wasm_bindgen]
@@ -457,7 +614,7 @@ impl ThresholdResult {
 
     /// The output (thresholded) matrix.  Consumes the result.
     #[wasm_bindgen(js_name = "getMatrix")]
-    pub fn get_matrix(self) -> PureCvMatrixF32 {
+    pub fn get_matrix(self) -> Mat {
         self.matrix
     }
 }
@@ -467,22 +624,26 @@ impl ThresholdResult {
 /// * `threshold_type`: 0 = BINARY, 1 = BINARY_INV, 2 = TRUNC, 3 = TOZERO, 4 = TOZERO_INV.
 #[wasm_bindgen(js_name = "threshold")]
 pub fn apply_threshold(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     thresh: f64,
     maxval: f64,
     threshold_type: i32,
 ) -> Result<ThresholdResult, JsError> {
+    let m = require_f32(src, "threshold")?;
     let tt = thresh_type_from_i32(threshold_type)?;
-    let (tv, mat) =
-        threshold(&src.inner, thresh, maxval, tt).map_err(|e| JsError::new(&format!("{e}")))?;
+    let (tv, mat) = threshold(m, thresh, maxval, tt).map_err(|e| JsError::new(&format!("{e}")))?;
     Ok(ThresholdResult {
         thresh_val: tv,
-        matrix: PureCvMatrixF32 { inner: mat },
+        matrix: Mat {
+            inner: DynamicMatrix {
+                data: DynamicData::F32(mat),
+            },
+        },
     })
 }
 
 // ---------------------------------------------------------------------------
-//  Edge detection (f32 → u8 for Canny, f32 → f32 for Sobel/Scharr/Laplacian)
+//  Edge detection (requires f32 depth)
 // ---------------------------------------------------------------------------
 
 /// Helper to convert a JS integer into a `BorderTypes`.
@@ -500,27 +661,26 @@ fn border_type_from_i32(bt: i32) -> Result<BorderTypes, JsError> {
 }
 
 /// Canny edge detection.  Input must be single-channel f32.
-/// Returns an 8-bit edge map.
+/// Returns a u8 edge map.
 ///
 /// * `aperture_size` – Sobel kernel size (default: 3).
 /// * `l2_gradient`   – Use L₂ norm (true) or L₁ norm (false).
 #[wasm_bindgen(js_name = "canny")]
 pub fn canny(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     threshold1: f64,
     threshold2: f64,
     aperture_size: i32,
     l2_gradient: bool,
-) -> Result<PureCvMatrixU8, JsError> {
-    let result = edge::canny(
-        &src.inner,
-        threshold1,
-        threshold2,
-        aperture_size,
-        l2_gradient,
-    )
-    .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixU8 { inner: result })
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "canny")?;
+    let result = edge::canny(m, threshold1, threshold2, aperture_size, l2_gradient)
+        .map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::U8(result),
+        },
+    })
 }
 
 /// Sobel derivative filter.
@@ -531,53 +691,68 @@ pub fn canny(
 /// * `border_type`   – Border interpolation (integer, see `BorderTypes`).
 #[wasm_bindgen(js_name = "sobel")]
 pub fn sobel(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     dx: i32,
     dy: i32,
     ksize: i32,
     scale: f64,
     delta: f64,
     border_type: i32,
-) -> Result<PureCvMatrixF32, JsError> {
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "sobel")?;
     let bt = border_type_from_i32(border_type)?;
-    let result = derivatives::sobel(&src.inner, dx, dy, ksize, scale, delta, bt)
+    let result = derivatives::sobel(m, dx, dy, ksize, scale, delta, bt)
         .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Scharr derivative filter (equivalent to Sobel with ksize = -1).
 #[wasm_bindgen(js_name = "scharr")]
 pub fn scharr(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     dx: i32,
     dy: i32,
     scale: f64,
     delta: f64,
     border_type: i32,
-) -> Result<PureCvMatrixF32, JsError> {
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "scharr")?;
     let bt = border_type_from_i32(border_type)?;
-    let result = derivatives::scharr(&src.inner, dx, dy, scale, delta, bt)
+    let result = derivatives::scharr(m, dx, dy, scale, delta, bt)
         .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Laplacian of an image.
 #[wasm_bindgen(js_name = "laplacian")]
 pub fn laplacian(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     ksize: i32,
     scale: f64,
     delta: f64,
     border_type: i32,
-) -> Result<PureCvMatrixF32, JsError> {
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "laplacian")?;
     let bt = border_type_from_i32(border_type)?;
-    let result = derivatives::laplacian(&src.inner, ksize, scale, delta, bt)
+    let result = derivatives::laplacian(m, ksize, scale, delta, bt)
         .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------
-//  Blur / filter operations (f32)
+//  Blur / filter operations (require f32 depth)
 // ---------------------------------------------------------------------------
 
 /// Box blur (mean filter).
@@ -586,17 +761,22 @@ pub fn laplacian(
 /// * `border_type`        – Border interpolation (integer, see `BorderTypes`).
 #[wasm_bindgen(js_name = "blur")]
 pub fn blur(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     ksize_w: i32,
     ksize_h: i32,
     border_type: i32,
-) -> Result<PureCvMatrixF32, JsError> {
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "blur")?;
     let bt = border_type_from_i32(border_type)?;
     let ksize = Size2i::new(ksize_w, ksize_h);
     let anchor = Point2i::new(-1, -1);
     let result =
-        filter::blur(&src.inner, ksize, anchor, bt).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+        filter::blur(m, ksize, anchor, bt).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Gaussian blur.
@@ -607,28 +787,38 @@ pub fn blur(
 /// * `border_type`        – Border interpolation (integer).
 #[wasm_bindgen(js_name = "gaussianBlur")]
 pub fn gaussian_blur(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     ksize_w: i32,
     ksize_h: i32,
     sigma1: f64,
     sigma2: f64,
     border_type: i32,
-) -> Result<PureCvMatrixF32, JsError> {
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "gaussianBlur")?;
     let bt = border_type_from_i32(border_type)?;
     let ksize = Size2i::new(ksize_w, ksize_h);
-    let result = filter::gaussian_blur(&src.inner, ksize, sigma1, sigma2, bt)
+    let result = filter::gaussian_blur(m, ksize, sigma1, sigma2, bt)
         .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Median blur.
 ///
 /// * `ksize` – Aperture size (must be odd and > 1).
 #[wasm_bindgen(js_name = "medianBlur")]
-pub fn median_blur(src: &PureCvMatrixF32, ksize: i32) -> Result<PureCvMatrixF32, JsError> {
+pub fn median_blur(src: &Mat, ksize: i32) -> Result<Mat, JsError> {
+    let m = require_f32(src, "medianBlur")?;
     let result =
-        filter::median_blur(&src.inner, ksize).map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+        filter::median_blur(m, ksize).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 /// Bilateral filter.
@@ -639,16 +829,21 @@ pub fn median_blur(src: &PureCvMatrixF32, ksize: i32) -> Result<PureCvMatrixF32,
 /// * `border_type` – Border interpolation (integer).
 #[wasm_bindgen(js_name = "bilateralFilter")]
 pub fn bilateral_filter(
-    src: &PureCvMatrixF32,
+    src: &Mat,
     d: i32,
     sigma_color: f64,
     sigma_space: f64,
     border_type: i32,
-) -> Result<PureCvMatrixF32, JsError> {
+) -> Result<Mat, JsError> {
+    let m = require_f32(src, "bilateralFilter")?;
     let bt = border_type_from_i32(border_type)?;
-    let result = filter::bilateral_filter(&src.inner, d, sigma_color, sigma_space, bt)
+    let result = filter::bilateral_filter(m, d, sigma_color, sigma_space, bt)
         .map_err(|e| JsError::new(&format!("{e}")))?;
-    Ok(PureCvMatrixF32 { inner: result })
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(result),
+        },
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -269,45 +269,36 @@ impl Mat {
     /// Errors if this Mat is not of depth `u8`.
     #[wasm_bindgen(js_name = "dataU8")]
     pub fn data_u8(&self) -> Result<Vec<u8>, JsError> {
-        self.inner
-            .data_u8()
-            .map(|s| s.to_vec())
-            .ok_or_else(|| {
-                JsError::new(&format!(
-                    "dataU8() requires u8 depth, but Mat has depth '{}'",
-                    self.inner.depth_name()
-                ))
-            })
+        self.inner.data_u8().map(|s| s.to_vec()).ok_or_else(|| {
+            JsError::new(&format!(
+                "dataU8() requires u8 depth, but Mat has depth '{}'",
+                self.inner.depth_name()
+            ))
+        })
     }
 
     /// Returns a copy of the underlying data as a `Float32Array`.
     /// Errors if this Mat is not of depth `f32`.
     #[wasm_bindgen(js_name = "dataF32")]
     pub fn data_f32(&self) -> Result<Vec<f32>, JsError> {
-        self.inner
-            .data_f32()
-            .map(|s| s.to_vec())
-            .ok_or_else(|| {
-                JsError::new(&format!(
-                    "dataF32() requires f32 depth, but Mat has depth '{}'",
-                    self.inner.depth_name()
-                ))
-            })
+        self.inner.data_f32().map(|s| s.to_vec()).ok_or_else(|| {
+            JsError::new(&format!(
+                "dataF32() requires f32 depth, but Mat has depth '{}'",
+                self.inner.depth_name()
+            ))
+        })
     }
 
     /// Returns a copy of the underlying data as a `Float64Array`.
     /// Errors if this Mat is not of depth `f64`.
     #[wasm_bindgen(js_name = "dataF64")]
     pub fn data_f64(&self) -> Result<Vec<f64>, JsError> {
-        self.inner
-            .data_f64()
-            .map(|s| s.to_vec())
-            .ok_or_else(|| {
-                JsError::new(&format!(
-                    "dataF64() requires f64 depth, but Mat has depth '{}'",
-                    self.inner.depth_name()
-                ))
-            })
+        self.inner.data_f64().map(|s| s.to_vec()).ok_or_else(|| {
+            JsError::new(&format!(
+                "dataF64() requires f64 depth, but Mat has depth '{}'",
+                self.inner.depth_name()
+            ))
+        })
     }
 
     /// Sets the underlying data from a `Uint8Array`. Errors if depth is not `u8`.
@@ -501,45 +492,93 @@ pub fn max(a: &Mat, b: &Mat) -> Result<Mat, JsError> {
 #[wasm_bindgen(js_name = "flip")]
 pub fn flip(src: &Mat, flip_code: i32) -> Result<Mat, JsError> {
     let data = match &src.inner.data {
-        DynamicData::U8(m) => DynamicData::U8(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I8(m) => DynamicData::I8(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::U16(m) => DynamicData::U16(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I16(m) => DynamicData::I16(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I32(m) => DynamicData::I32(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::F32(m) => DynamicData::F32(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::F64(m) => DynamicData::F64(structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::U8(m) => DynamicData::U8(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::I8(m) => DynamicData::I8(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::U16(m) => DynamicData::U16(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::I16(m) => DynamicData::I16(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::I32(m) => DynamicData::I32(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::F32(m) => DynamicData::F32(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::F64(m) => DynamicData::F64(
+            structural::flip(m, flip_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
     };
-    Ok(Mat { inner: DynamicMatrix { data } })
+    Ok(Mat {
+        inner: DynamicMatrix { data },
+    })
 }
 
 /// Transposes a matrix (swaps rows and columns).
 #[wasm_bindgen(js_name = "transpose")]
 pub fn transpose(src: &Mat) -> Result<Mat, JsError> {
     let data = match &src.inner.data {
-        DynamicData::U8(m) => DynamicData::U8(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I8(m) => DynamicData::I8(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::U16(m) => DynamicData::U16(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I16(m) => DynamicData::I16(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I32(m) => DynamicData::I32(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::F32(m) => DynamicData::F32(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::F64(m) => DynamicData::F64(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::U8(m) => {
+            DynamicData::U8(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
+        DynamicData::I8(m) => {
+            DynamicData::I8(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
+        DynamicData::U16(m) => {
+            DynamicData::U16(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
+        DynamicData::I16(m) => {
+            DynamicData::I16(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
+        DynamicData::I32(m) => {
+            DynamicData::I32(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
+        DynamicData::F32(m) => {
+            DynamicData::F32(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
+        DynamicData::F64(m) => {
+            DynamicData::F64(structural::transpose(m).map_err(|e| JsError::new(&format!("{e}")))?)
+        }
     };
-    Ok(Mat { inner: DynamicMatrix { data } })
+    Ok(Mat {
+        inner: DynamicMatrix { data },
+    })
 }
 
 /// Rotates a matrix: 0 = 90° CW, 1 = 180°, 2 = 90° CCW.
 #[wasm_bindgen(js_name = "rotate")]
 pub fn rotate(src: &Mat, rotate_code: i32) -> Result<Mat, JsError> {
     let data = match &src.inner.data {
-        DynamicData::U8(m) => DynamicData::U8(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I8(m) => DynamicData::I8(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::U16(m) => DynamicData::U16(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I16(m) => DynamicData::I16(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::I32(m) => DynamicData::I32(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::F32(m) => DynamicData::F32(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
-        DynamicData::F64(m) => DynamicData::F64(structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?),
+        DynamicData::U8(m) => DynamicData::U8(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::I8(m) => DynamicData::I8(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::U16(m) => DynamicData::U16(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::I16(m) => DynamicData::I16(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::I32(m) => DynamicData::I32(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::F32(m) => DynamicData::F32(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
+        DynamicData::F64(m) => DynamicData::F64(
+            structural::rotate(m, rotate_code).map_err(|e| JsError::new(&format!("{e}")))?,
+        ),
     };
-    Ok(Mat { inner: DynamicMatrix { data } })
+    Ok(Mat {
+        inner: DynamicMatrix { data },
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -760,18 +799,12 @@ pub fn laplacian(
 /// * `ksize_w`, `ksize_h` – Kernel width and height.
 /// * `border_type`        – Border interpolation (integer, see `BorderTypes`).
 #[wasm_bindgen(js_name = "blur")]
-pub fn blur(
-    src: &Mat,
-    ksize_w: i32,
-    ksize_h: i32,
-    border_type: i32,
-) -> Result<Mat, JsError> {
+pub fn blur(src: &Mat, ksize_w: i32, ksize_h: i32, border_type: i32) -> Result<Mat, JsError> {
     let m = require_f32(src, "blur")?;
     let bt = border_type_from_i32(border_type)?;
     let ksize = Size2i::new(ksize_w, ksize_h);
     let anchor = Point2i::new(-1, -1);
-    let result =
-        filter::blur(m, ksize, anchor, bt).map_err(|e| JsError::new(&format!("{e}")))?;
+    let result = filter::blur(m, ksize, anchor, bt).map_err(|e| JsError::new(&format!("{e}")))?;
     Ok(Mat {
         inner: DynamicMatrix {
             data: DynamicData::F32(result),
@@ -812,8 +845,7 @@ pub fn gaussian_blur(
 #[wasm_bindgen(js_name = "medianBlur")]
 pub fn median_blur(src: &Mat, ksize: i32) -> Result<Mat, JsError> {
     let m = require_f32(src, "medianBlur")?;
-    let result =
-        filter::median_blur(m, ksize).map_err(|e| JsError::new(&format!("{e}")))?;
+    let result = filter::median_blur(m, ksize).map_err(|e| JsError::new(&format!("{e}")))?;
     Ok(Mat {
         inner: DynamicMatrix {
             data: DynamicData::F32(result),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -38,6 +38,7 @@ use wasm_bindgen::prelude::*;
 
 use purecv::core::arithm;
 use purecv::core::dynamic::{DynamicData, DynamicMatrix};
+use purecv::core::matrix::MatType;
 use purecv::core::structural;
 use purecv::core::types::{BorderTypes, Point2i, Size2i};
 use purecv::core::Matrix;
@@ -85,8 +86,14 @@ pub fn init_purecv() {
 /// An opaque wrapper around `DynamicMatrix`, exposed as `Mat` in JavaScript.
 ///
 /// This is the single matrix type used across the entire WASM API.
-/// The element depth (`u8`, `f32`, `f64`, etc.) is selected at construction
-/// time and can be queried or converted at runtime.
+/// The element depth and number of channels are selected at construction time
+/// via an OpenCV-style `MatType` integer (e.g. `CV_8UC3()`, `CV_32FC1()`).
+///
+/// ```js
+/// // Equivalent to cv::Mat m(480, 640, CV_8UC3) in C++ OpenCV
+/// const frame = new Mat(480, 640, CV_8UC3());
+/// const hdr   = new Mat(4,   4,   CV_32FC1());
+/// ```
 #[wasm_bindgen(js_name = "Mat")]
 pub struct Mat {
     inner: DynamicMatrix,
@@ -116,50 +123,31 @@ fn require_u8<'a>(mat: &'a Mat, op_name: &str) -> Result<&'a Matrix<u8>, JsError
 impl Mat {
     // -- Constructors -------------------------------------------------------
 
-    /// Creates a new zero-filled matrix with the given depth.
+    /// Creates a new zero-filled matrix.
     ///
     /// * `rows`     – Number of rows (height).
     /// * `cols`     – Number of columns (width).
-    /// * `channels` – Number of channels (e.g. 1 for gray, 3 for RGB, 4 for RGBA).
-    /// * `depth`    – Element type: `"u8"`, `"i8"`, `"u16"`, `"i16"`, `"i32"`, `"f32"`, `"f64"`.
-    ///               Defaults to `"f32"` if omitted or empty.
+    /// * `mat_type` – OpenCV-style type integer encoding depth + channels.
+    ///               Use the exported constants: `CV_8UC1()`, `CV_8UC3()`,
+    ///               `CV_32FC1()`, etc.
+    ///
+    /// ```js
+    /// const frame = new Mat(480, 640, CV_8UC3());   // u8, 3 channels
+    /// const mask  = new Mat(480, 640, CV_8UC1());   // u8, 1 channel
+    /// const hdr   = new Mat(480, 640, CV_32FC3());  // f32, 3 channels
+    /// ```
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        rows: usize,
-        cols: usize,
-        channels: usize,
-        depth: Option<String>,
-    ) -> Result<Mat, JsError> {
-        let depth_str = depth.unwrap_or_else(|| "f32".to_string());
-        let dm = match depth_str.as_str() {
-            "u8" => DynamicMatrix::new_u8(rows, cols, channels, vec![0u8; rows * cols * channels]),
-            "i8" => DynamicMatrix::new_i8(rows, cols, channels, vec![0i8; rows * cols * channels]),
-            "u16" => {
-                DynamicMatrix::new_u16(rows, cols, channels, vec![0u16; rows * cols * channels])
-            }
-            "i16" => {
-                DynamicMatrix::new_i16(rows, cols, channels, vec![0i16; rows * cols * channels])
-            }
-            "i32" => {
-                DynamicMatrix::new_i32(rows, cols, channels, vec![0i32; rows * cols * channels])
-            }
-            "f32" => {
-                DynamicMatrix::new_f32(rows, cols, channels, vec![0f32; rows * cols * channels])
-            }
-            "f64" => {
-                DynamicMatrix::new_f64(rows, cols, channels, vec![0f64; rows * cols * channels])
-            }
-            other => {
-                return Err(JsError::new(&format!(
-                    "Unknown depth '{other}'. Use one of: u8, i8, u16, i16, i32, f32, f64"
-                )));
-            }
-        };
-        dm.map(|d| Mat { inner: d })
+    pub fn new(rows: usize, cols: usize, mat_type: i32) -> Result<Mat, JsError> {
+        DynamicMatrix::new(rows, cols, MatType(mat_type))
+            .map(|d| Mat { inner: d })
             .map_err(|e| JsError::new(&format!("{e}")))
     }
 
-    /// Creates a Mat from a `Uint8Array`.
+    /// Creates a Mat from a `Uint8Array` (CV_8U depth).
+    ///
+    /// ```js
+    /// const mat = Mat.fromU8Data(2, 2, 3, new Uint8Array([r,g,b, r,g,b, r,g,b, r,g,b]));
+    /// ```
     #[wasm_bindgen(js_name = "fromU8Data")]
     pub fn from_u8_data(
         rows: usize,
@@ -167,23 +155,12 @@ impl Mat {
         channels: usize,
         data: &[u8],
     ) -> Result<Mat, JsError> {
-        let expected = rows * cols * channels;
-        if data.len() != expected {
-            return Err(JsError::new(&format!(
-                "Data length {} does not match {}×{}×{} = {}",
-                data.len(),
-                rows,
-                cols,
-                channels,
-                expected
-            )));
-        }
         let dm = DynamicMatrix::new_u8(rows, cols, channels, data.to_vec())
             .map_err(|e| JsError::new(&format!("{e}")))?;
         Ok(Mat { inner: dm })
     }
 
-    /// Creates a Mat from a `Float32Array`.
+    /// Creates a Mat from a `Float32Array` (CV_32F depth).
     #[wasm_bindgen(js_name = "fromF32Data")]
     pub fn from_f32_data(
         rows: usize,
@@ -191,23 +168,12 @@ impl Mat {
         channels: usize,
         data: &[f32],
     ) -> Result<Mat, JsError> {
-        let expected = rows * cols * channels;
-        if data.len() != expected {
-            return Err(JsError::new(&format!(
-                "Data length {} does not match {}×{}×{} = {}",
-                data.len(),
-                rows,
-                cols,
-                channels,
-                expected
-            )));
-        }
         let dm = DynamicMatrix::new_f32(rows, cols, channels, data.to_vec())
             .map_err(|e| JsError::new(&format!("{e}")))?;
         Ok(Mat { inner: dm })
     }
 
-    /// Creates a Mat from a `Float64Array`.
+    /// Creates a Mat from a `Float64Array` (CV_64F depth).
     #[wasm_bindgen(js_name = "fromF64Data")]
     pub fn from_f64_data(
         rows: usize,
@@ -215,17 +181,6 @@ impl Mat {
         channels: usize,
         data: &[f64],
     ) -> Result<Mat, JsError> {
-        let expected = rows * cols * channels;
-        if data.len() != expected {
-            return Err(JsError::new(&format!(
-                "Data length {} does not match {}×{}×{} = {}",
-                data.len(),
-                rows,
-                cols,
-                channels,
-                expected
-            )));
-        }
         let dm = DynamicMatrix::new_f64(rows, cols, channels, data.to_vec())
             .map_err(|e| JsError::new(&format!("{e}")))?;
         Ok(Mat { inner: dm })
@@ -255,6 +210,13 @@ impl Mat {
     #[wasm_bindgen(getter, js_name = "length")]
     pub fn length(&self) -> usize {
         self.inner.total()
+    }
+
+    /// Returns the OpenCV-style type integer (encodes depth + channels).
+    /// This value matches the constants `CV_8UC3()`, `CV_32FC1()`, etc.
+    #[wasm_bindgen(getter, js_name = "type")]
+    pub fn mat_type(&self) -> i32 {
+        self.inner.mat_type().to_int()
     }
 
     /// Returns the element depth as a string (e.g. `"u8"`, `"f32"`).
@@ -724,10 +686,10 @@ pub fn canny(
 
 /// Sobel derivative filter.
 ///
-/// * `dx`, `dy`      – Order of the derivative in x / y.
-/// * `ksize`         – Aperture size (1, 3, 5, or 7; -1 = Scharr).
+/// * `dx`, `dy`       – Order of the derivative in x / y.
+/// * `ksize`          – Aperture size (1, 3, 5, or 7; -1 = Scharr).
 /// * `scale`, `delta` – Scale factor and optional offset.
-/// * `border_type`   – Border interpolation (integer, see `BorderTypes`).
+/// * `border_type`    – Border interpolation (integer, see `BorderTypes`).
 #[wasm_bindgen(js_name = "sobel")]
 pub fn sobel(
     src: &Mat,
@@ -879,10 +841,132 @@ pub fn bilateral_filter(
 }
 
 // ---------------------------------------------------------------------------
-//  JS-side enum constants (exposed as getter functions)
+//  JS-side enum constants
 // ---------------------------------------------------------------------------
 
-// Color conversion codes
+// -- MatType constants (depth + channels encoded as i32) --------------------
+
+#[wasm_bindgen(js_name = "CV_8UC1")]
+pub fn cv_8uc1() -> i32 {
+    0
+} // CV_8U,  1ch
+#[wasm_bindgen(js_name = "CV_8UC2")]
+pub fn cv_8uc2() -> i32 {
+    8
+} // CV_8U,  2ch
+#[wasm_bindgen(js_name = "CV_8UC3")]
+pub fn cv_8uc3() -> i32 {
+    16
+} // CV_8U,  3ch
+#[wasm_bindgen(js_name = "CV_8UC4")]
+pub fn cv_8uc4() -> i32 {
+    24
+} // CV_8U,  4ch
+
+#[wasm_bindgen(js_name = "CV_8SC1")]
+pub fn cv_8sc1() -> i32 {
+    1
+} // CV_8S,  1ch
+#[wasm_bindgen(js_name = "CV_8SC2")]
+pub fn cv_8sc2() -> i32 {
+    9
+}
+#[wasm_bindgen(js_name = "CV_8SC3")]
+pub fn cv_8sc3() -> i32 {
+    17
+}
+#[wasm_bindgen(js_name = "CV_8SC4")]
+pub fn cv_8sc4() -> i32 {
+    25
+}
+
+#[wasm_bindgen(js_name = "CV_16UC1")]
+pub fn cv_16uc1() -> i32 {
+    2
+} // CV_16U, 1ch
+#[wasm_bindgen(js_name = "CV_16UC2")]
+pub fn cv_16uc2() -> i32 {
+    10
+}
+#[wasm_bindgen(js_name = "CV_16UC3")]
+pub fn cv_16uc3() -> i32 {
+    18
+}
+#[wasm_bindgen(js_name = "CV_16UC4")]
+pub fn cv_16uc4() -> i32 {
+    26
+}
+
+#[wasm_bindgen(js_name = "CV_16SC1")]
+pub fn cv_16sc1() -> i32 {
+    3
+} // CV_16S, 1ch
+#[wasm_bindgen(js_name = "CV_16SC2")]
+pub fn cv_16sc2() -> i32 {
+    11
+}
+#[wasm_bindgen(js_name = "CV_16SC3")]
+pub fn cv_16sc3() -> i32 {
+    19
+}
+#[wasm_bindgen(js_name = "CV_16SC4")]
+pub fn cv_16sc4() -> i32 {
+    27
+}
+
+#[wasm_bindgen(js_name = "CV_32SC1")]
+pub fn cv_32sc1() -> i32 {
+    4
+} // CV_32S, 1ch
+#[wasm_bindgen(js_name = "CV_32SC2")]
+pub fn cv_32sc2() -> i32 {
+    12
+}
+#[wasm_bindgen(js_name = "CV_32SC3")]
+pub fn cv_32sc3() -> i32 {
+    20
+}
+#[wasm_bindgen(js_name = "CV_32SC4")]
+pub fn cv_32sc4() -> i32 {
+    28
+}
+
+#[wasm_bindgen(js_name = "CV_32FC1")]
+pub fn cv_32fc1() -> i32 {
+    5
+} // CV_32F, 1ch
+#[wasm_bindgen(js_name = "CV_32FC2")]
+pub fn cv_32fc2() -> i32 {
+    13
+}
+#[wasm_bindgen(js_name = "CV_32FC3")]
+pub fn cv_32fc3() -> i32 {
+    21
+}
+#[wasm_bindgen(js_name = "CV_32FC4")]
+pub fn cv_32fc4() -> i32 {
+    29
+}
+
+#[wasm_bindgen(js_name = "CV_64FC1")]
+pub fn cv_64fc1() -> i32 {
+    6
+} // CV_64F, 1ch
+#[wasm_bindgen(js_name = "CV_64FC2")]
+pub fn cv_64fc2() -> i32 {
+    14
+}
+#[wasm_bindgen(js_name = "CV_64FC3")]
+pub fn cv_64fc3() -> i32 {
+    22
+}
+#[wasm_bindgen(js_name = "CV_64FC4")]
+pub fn cv_64fc4() -> i32 {
+    30
+}
+
+// -- Color conversion codes -------------------------------------------------
+
 #[wasm_bindgen(js_name = "COLOR_BGR2GRAY")]
 pub fn color_bgr2gray() -> i32 {
     0
@@ -916,7 +1000,8 @@ pub fn color_gray2bgra() -> i32 {
     7
 }
 
-// Threshold types
+// -- Threshold types --------------------------------------------------------
+
 #[wasm_bindgen(js_name = "THRESH_BINARY")]
 pub fn thresh_binary() -> i32 {
     0
@@ -938,7 +1023,8 @@ pub fn thresh_tozero_inv() -> i32 {
     4
 }
 
-// Border types
+// -- Border types -----------------------------------------------------------
+
 #[wasm_bindgen(js_name = "BORDER_CONSTANT")]
 pub fn border_constant() -> i32 {
     0
@@ -960,7 +1046,8 @@ pub fn border_reflect_101() -> i32 {
     4
 }
 
-// Flip codes
+// -- Flip codes -------------------------------------------------------------
+
 #[wasm_bindgen(js_name = "FLIP_VERTICAL")]
 pub fn flip_vertical() -> i32 {
     0
@@ -974,7 +1061,8 @@ pub fn flip_both() -> i32 {
     -1
 }
 
-// Rotate codes
+// -- Rotate codes -----------------------------------------------------------
+
 #[wasm_bindgen(js_name = "ROTATE_90_CLOCKWISE")]
 pub fn rotate_90_clockwise() -> i32 {
     0

--- a/crates/wasm/www/simple_butterfly.js
+++ b/crates/wasm/www/simple_butterfly.js
@@ -166,51 +166,52 @@ async function run() {
         }
 
         // Wrap in purecv matrix
-        const matRgbU8 = m.PureCvMatrixU8.fromData(height, width, 3, rgbU8);
+        const matRgbU8 = m.Mat.fromU8Data(height, width, 3, rgbU8);
+
 
         // ── Greyscale (u8) ───────────────────────────────────────────────────
         log('cvtColor RGB→Gray…', 'info');
         const matGrayU8 = m.cvtColor(matRgbU8, m.COLOR_RGB2GRAY());
-        drawGray('c-gray', matGrayU8.data(), width, height);
+        drawGray('c-gray', matGrayU8.dataU8(), width, height);
         log('Greyscale ✓');
 
         // Convert grey to f32 for filter/edge ops
-        const matGrayF32 = m.convertU8ToF32(matGrayU8);
+        const matGrayF32 = matGrayU8.convertTo("f32");
         // Convert colour to f32 for blur ops (blur* only accept f32)
-        const matRgbF32 = m.convertU8ToF32(matRgbU8);
+        const matRgbF32 = matRgbU8.convertTo("f32");
 
         const BORDER = m.BORDER_REFLECT_101();
 
         // ── Blur 5×5 ─────────────────────────────────────────────────────────
         log('blur 5×5…', 'info');
         const matBlurF32 = m.blur(matRgbF32, 5, 5, BORDER);
-        const blurU8 = m.convertF32ToU8(matBlurF32);
-        drawRGB('c-blur', blurU8.data(), width, height);
+        const blurU8 = matBlurF32.convertTo("u8");
+        drawRGB('c-blur', blurU8.dataU8(), width, height);
         log('Blur ✓');
 
         // ── Gaussian Blur 5×5 σ=1.75   ──────────────────────────────────────────
         log('gaussianBlur 5×5 σ=1.75…', 'info');
         const matGaussF32 = m.gaussianBlur(matRgbF32, 5, 5, 1.75, 1.75, BORDER);
-        const gaussU8 = m.convertF32ToU8(matGaussF32);
-        drawRGB('c-gauss', gaussU8.data(), width, height);
+        const gaussU8 = matGaussF32.convertTo("u8");
+        drawRGB('c-gauss', gaussU8.dataU8(), width, height);
         log('Gaussian blur ✓');
 
         // ── Canny ─────────────────────────────────────────────────────────────
         log('canny lo=50 hi=150…', 'info');
         const matCanny = m.canny(matGrayF32, 50, 150, 3, false);
-        drawGray('c-canny', matCanny.data(), width, height);
+        drawGray('c-canny', matCanny.dataU8(), width, height);
         log('Canny ✓');
 
         // ── Sobel X ───────────────────────────────────────────────────────────
         log('sobel dx=1 dy=0 k=3…', 'info');
         const matSobelF32 = m.sobel(matGrayF32, 1, 0, 3, 1.0, 0.0, BORDER);
-        drawGray('c-sobel', normalizeF32(matSobelF32.data()), width, height);
+        drawGray('c-sobel', normalizeF32(matSobelF32.dataF32()), width, height);
         log('Sobel ✓');
 
         // ── Laplacian ─────────────────────────────────────────────────────────
         log('laplacian k=3…', 'info');
         const matLapF32 = m.laplacian(matGrayF32, 3, 1.0, 0.0, BORDER);
-        drawGray('c-laplacian', normalizeF32(matLapF32.data()), width, height);
+        drawGray('c-laplacian', normalizeF32(matLapF32.dataF32()), width, height);
         log('Laplacian ✓');
 
         // ── Threshold binary 127 ──────────────────────────────────────────────
@@ -218,7 +219,7 @@ async function run() {
         const threshResult = m.threshold(matGrayF32, 127.0, 255.0, m.THRESH_BINARY());
         const threshVal = threshResult.threshVal;  // read BEFORE getMatrix() consumes the object
         const threshMat = threshResult.getMatrix(); // moves self — threshResult is now invalid
-        drawGray('c-thresh', normalizeF32(threshMat.data()), width, height);
+        drawGray('c-thresh', normalizeF32(threshMat.dataF32()), width, height);
         log(`Threshold ✓  (val=${threshVal})`);
 
         // Cleanup

--- a/crates/wasm/www/simple_butterfly_example.html
+++ b/crates/wasm/www/simple_butterfly_example.html
@@ -214,7 +214,7 @@
     <p class="info">[log] Starting…</p>
   </div>
 
-  <script type="module" src="main.js"></script>
+  <script type="module" src="simple_butterfly.js"></script>
 
 </body>
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -35,6 +35,7 @@
  */
 
 pub mod arithm;
+pub mod dynamic;
 pub mod error;
 pub mod matrix;
 pub mod rng;
@@ -42,6 +43,11 @@ pub(crate) mod simd;
 pub mod structural;
 pub mod types;
 pub mod utils;
+
+#[macro_use]
+pub mod macros {
+    // Re-export macro if we need to put it somewhere, or just trust #macro_export handles it
+}
 
 #[cfg(test)]
 mod tests;
@@ -54,6 +60,7 @@ pub use self::arithm::{
     polar_to_cart, reduce, set_identity, solve, solve_poly, sort, sort_idx, subtract, sum, trace,
     transform, DecompTypes, GEMM_1_T, GEMM_2_T, GEMM_3_T,
 };
+pub use self::dynamic::{DynamicData, DynamicMatrix};
 pub use self::error::{PureCvError, Result};
 pub use self::matrix::{
     DataType, Depth, MatType, Matrix, CV_16S, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_16U,

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -208,7 +208,7 @@ impl DynamicMatrix {
             DynamicData::I16(m) => m.at(row, col, channel).map(|v| *v as f64),
             DynamicData::I32(m) => m.at(row, col, channel).map(|v| *v as f64),
             DynamicData::F32(m) => m.at(row, col, channel).map(|v| *v as f64),
-            DynamicData::F64(m) => m.at(row, col, channel).map(|v| *v),
+            DynamicData::F64(m) => m.at(row, col, channel).copied(),
         }
     }
 

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -208,7 +208,7 @@ impl DynamicMatrix {
             DynamicData::I16(m) => m.at(row, col, channel).map(|v| *v as f64),
             DynamicData::I32(m) => m.at(row, col, channel).map(|v| *v as f64),
             DynamicData::F32(m) => m.at(row, col, channel).map(|v| *v as f64),
-            DynamicData::F64(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::F64(m) => m.at(row, col, channel).map(|v| *v),
         }
     }
 

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -86,7 +86,7 @@ impl DynamicMatrix {
     /// ```rust
     /// use purecv::core::DynamicMatrix;
     /// use purecv::core::matrix::CV_8UC3;
-    /// 
+    ///
     /// let frame = DynamicMatrix::new(480, 640, CV_8UC3).unwrap();
     /// ```
     pub fn new(rows: usize, cols: usize, mat_type: MatType) -> Result<Self> {

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -219,16 +219,30 @@ impl DynamicMatrix {
         macro_rules! convert_inner {
             ($src_mat:expr, $depth:expr) => {
                 match $depth {
-                    "u8" => Ok(DynamicMatrix { data: DynamicData::U8($src_mat.convert_to::<u8>()?) }),
-                    "i8" => Ok(DynamicMatrix { data: DynamicData::I8($src_mat.convert_to::<i8>()?) }),
-                    "u16" => Ok(DynamicMatrix { data: DynamicData::U16($src_mat.convert_to::<u16>()?) }),
-                    "i16" => Ok(DynamicMatrix { data: DynamicData::I16($src_mat.convert_to::<i16>()?) }),
-                    "i32" => Ok(DynamicMatrix { data: DynamicData::I32($src_mat.convert_to::<i32>()?) }),
-                    "f32" => Ok(DynamicMatrix { data: DynamicData::F32($src_mat.convert_to::<f32>()?) }),
-                    "f64" => Ok(DynamicMatrix { data: DynamicData::F64($src_mat.convert_to::<f64>()?) }),
-                    other => Err(crate::core::error::PureCvError::InvalidInput(
-                        format!("Unknown depth: {other}")
-                    )),
+                    "u8" => Ok(DynamicMatrix {
+                        data: DynamicData::U8($src_mat.convert_to::<u8>()?),
+                    }),
+                    "i8" => Ok(DynamicMatrix {
+                        data: DynamicData::I8($src_mat.convert_to::<i8>()?),
+                    }),
+                    "u16" => Ok(DynamicMatrix {
+                        data: DynamicData::U16($src_mat.convert_to::<u16>()?),
+                    }),
+                    "i16" => Ok(DynamicMatrix {
+                        data: DynamicData::I16($src_mat.convert_to::<i16>()?),
+                    }),
+                    "i32" => Ok(DynamicMatrix {
+                        data: DynamicData::I32($src_mat.convert_to::<i32>()?),
+                    }),
+                    "f32" => Ok(DynamicMatrix {
+                        data: DynamicData::F32($src_mat.convert_to::<f32>()?),
+                    }),
+                    "f64" => Ok(DynamicMatrix {
+                        data: DynamicData::F64($src_mat.convert_to::<f64>()?),
+                    }),
+                    other => Err(crate::core::error::PureCvError::InvalidInput(format!(
+                        "Unknown depth: {other}"
+                    ))),
                 }
             };
         }

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -1,0 +1,245 @@
+/*
+ *  dynamic.rs
+ *  purecv
+ *
+ *  This file is part of purecv - OpenCV.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan <https://github.com/kalwalt>
+ *
+ */
+
+use crate::core::error::Result;
+use crate::core::matrix::Matrix;
+
+/// An enum bridging type-erased dynamic usage to strongly typed generic `Matrix<T>`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DynamicData {
+    U8(Matrix<u8>),
+    I8(Matrix<i8>),
+    U16(Matrix<u16>),
+    I16(Matrix<i16>),
+    I32(Matrix<i32>),
+    F32(Matrix<f32>),
+    F64(Matrix<f64>),
+}
+
+/// A type-erased matrix that holds any dynamic OpenCV-like depth.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicMatrix {
+    pub data: DynamicData,
+}
+
+/// Macro for dispatching dynamic implementations to their underlying generic variants.
+#[macro_export]
+macro_rules! dispatch_dynamic {
+    ($data:expr, $mat:pat => $body:expr) => {
+        match $data {
+            $crate::core::dynamic::DynamicData::U8($mat) => $body,
+            $crate::core::dynamic::DynamicData::I8($mat) => $body,
+            $crate::core::dynamic::DynamicData::U16($mat) => $body,
+            $crate::core::dynamic::DynamicData::I16($mat) => $body,
+            $crate::core::dynamic::DynamicData::I32($mat) => $body,
+            $crate::core::dynamic::DynamicData::F32($mat) => $body,
+            $crate::core::dynamic::DynamicData::F64($mat) => $body,
+        }
+    };
+}
+
+impl DynamicMatrix {
+    pub fn new_u8(rows: usize, cols: usize, channels: usize, data: Vec<u8>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::U8(mat),
+        })
+    }
+
+    pub fn new_i8(rows: usize, cols: usize, channels: usize, data: Vec<i8>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::I8(mat),
+        })
+    }
+
+    pub fn new_u16(rows: usize, cols: usize, channels: usize, data: Vec<u16>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::U16(mat),
+        })
+    }
+
+    pub fn new_i16(rows: usize, cols: usize, channels: usize, data: Vec<i16>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::I16(mat),
+        })
+    }
+
+    pub fn new_i32(rows: usize, cols: usize, channels: usize, data: Vec<i32>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::I32(mat),
+        })
+    }
+
+    pub fn new_f32(rows: usize, cols: usize, channels: usize, data: Vec<f32>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::F32(mat),
+        })
+    }
+
+    pub fn new_f64(rows: usize, cols: usize, channels: usize, data: Vec<f64>) -> Result<Self> {
+        let mat = Matrix::from_vec(rows, cols, channels, data);
+        Ok(Self {
+            data: DynamicData::F64(mat),
+        })
+    }
+
+    pub fn rows(&self) -> usize {
+        dispatch_dynamic!(&self.data, mat => mat.rows)
+    }
+
+    pub fn cols(&self) -> usize {
+        dispatch_dynamic!(&self.data, mat => mat.cols)
+    }
+
+    pub fn channels(&self) -> usize {
+        dispatch_dynamic!(&self.data, mat => mat.channels)
+    }
+
+    /// Returns a human-readable name of the element depth (e.g. `"u8"`, `"f32"`).
+    pub fn depth_name(&self) -> &str {
+        match &self.data {
+            DynamicData::U8(_) => "u8",
+            DynamicData::I8(_) => "i8",
+            DynamicData::U16(_) => "u16",
+            DynamicData::I16(_) => "i16",
+            DynamicData::I32(_) => "i32",
+            DynamicData::F32(_) => "f32",
+            DynamicData::F64(_) => "f64",
+        }
+    }
+
+    /// Total number of elements (rows × cols × channels).
+    pub fn total(&self) -> usize {
+        dispatch_dynamic!(&self.data, mat => mat.data.len())
+    }
+
+    // -- Typed data accessors ------------------------------------------------
+
+    pub fn data_u8(&self) -> Option<&[u8]> {
+        match &self.data {
+            DynamicData::U8(m) => Some(&m.data),
+            _ => None,
+        }
+    }
+
+    pub fn data_f32(&self) -> Option<&[f32]> {
+        match &self.data {
+            DynamicData::F32(m) => Some(&m.data),
+            _ => None,
+        }
+    }
+
+    pub fn data_f64(&self) -> Option<&[f64]> {
+        match &self.data {
+            DynamicData::F64(m) => Some(&m.data),
+            _ => None,
+        }
+    }
+
+    // -- Typed matrix borrow -------------------------------------------------
+
+    pub fn as_matrix_u8(&self) -> Option<&Matrix<u8>> {
+        match &self.data {
+            DynamicData::U8(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub fn as_matrix_f32(&self) -> Option<&Matrix<f32>> {
+        match &self.data {
+            DynamicData::F32(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub fn as_matrix_f64(&self) -> Option<&Matrix<f64>> {
+        match &self.data {
+            DynamicData::F64(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    // -- Read a single element as f64 (for JS interop) -----------------------
+
+    /// Returns the element at `(row, col, channel)` cast to `f64`.
+    pub fn at_f64(&self, row: i32, col: i32, channel: usize) -> Option<f64> {
+        match &self.data {
+            DynamicData::U8(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::I8(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::U16(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::I16(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::I32(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::F32(m) => m.at(row, col, channel).map(|v| *v as f64),
+            DynamicData::F64(m) => m.at(row, col, channel).map(|v| *v as f64),
+        }
+    }
+
+    // -- Type conversion -----------------------------------------------------
+
+    /// Creates a new DynamicMatrix with a different element depth.
+    pub fn convert_to(&self, depth: &str) -> Result<DynamicMatrix> {
+        macro_rules! convert_inner {
+            ($src_mat:expr, $depth:expr) => {
+                match $depth {
+                    "u8" => Ok(DynamicMatrix { data: DynamicData::U8($src_mat.convert_to::<u8>()?) }),
+                    "i8" => Ok(DynamicMatrix { data: DynamicData::I8($src_mat.convert_to::<i8>()?) }),
+                    "u16" => Ok(DynamicMatrix { data: DynamicData::U16($src_mat.convert_to::<u16>()?) }),
+                    "i16" => Ok(DynamicMatrix { data: DynamicData::I16($src_mat.convert_to::<i16>()?) }),
+                    "i32" => Ok(DynamicMatrix { data: DynamicData::I32($src_mat.convert_to::<i32>()?) }),
+                    "f32" => Ok(DynamicMatrix { data: DynamicData::F32($src_mat.convert_to::<f32>()?) }),
+                    "f64" => Ok(DynamicMatrix { data: DynamicData::F64($src_mat.convert_to::<f64>()?) }),
+                    other => Err(crate::core::error::PureCvError::InvalidInput(
+                        format!("Unknown depth: {other}")
+                    )),
+                }
+            };
+        }
+        match &self.data {
+            DynamicData::U8(m) => convert_inner!(m, depth),
+            DynamicData::I8(m) => convert_inner!(m, depth),
+            DynamicData::U16(m) => convert_inner!(m, depth),
+            DynamicData::I16(m) => convert_inner!(m, depth),
+            DynamicData::I32(m) => convert_inner!(m, depth),
+            DynamicData::F32(m) => convert_inner!(m, depth),
+            DynamicData::F64(m) => convert_inner!(m, depth),
+        }
+    }
+}

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -34,8 +34,8 @@
  *
  */
 
-use crate::core::error::Result;
-use crate::core::matrix::Matrix;
+use crate::core::error::{PureCvError, Result};
+use crate::core::matrix::{Depth, MatType, Matrix};
 
 /// An enum bridging type-erased dynamic usage to strongly typed generic `Matrix<T>`.
 #[derive(Debug, Clone, PartialEq)]
@@ -72,54 +72,227 @@ macro_rules! dispatch_dynamic {
 }
 
 impl DynamicMatrix {
+    // -- OpenCV-style constructors (MatType as single type argument) ----------
+
+    /// Creates a new zero-filled matrix using an OpenCV-style `MatType`.
+    ///
+    /// This is the primary constructor, mirroring `cv::Mat m(rows, cols, CV_8UC3)`.
+    /// `MatType` encodes both depth and channels in a single `i32` value.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `CV_16F` is requested (not yet supported).
+    ///
+    /// # Example
+    /// ```rust
+    /// use purecv::core::DynamicMatrix;
+    /// use purecv::core::matrix::CV_8UC3;
+    /// 
+    /// let frame = DynamicMatrix::new(480, 640, CV_8UC3).unwrap();
+    /// ```
+    pub fn new(rows: usize, cols: usize, mat_type: MatType) -> Result<Self> {
+        let ch = mat_type.channels();
+        let n = rows * cols * ch;
+        let data = match mat_type.depth() {
+            Depth::CV_8U => DynamicData::U8(Matrix::from_vec(rows, cols, ch, vec![0u8; n])),
+            Depth::CV_8S => DynamicData::I8(Matrix::from_vec(rows, cols, ch, vec![0i8; n])),
+            Depth::CV_16U => DynamicData::U16(Matrix::from_vec(rows, cols, ch, vec![0u16; n])),
+            Depth::CV_16S => DynamicData::I16(Matrix::from_vec(rows, cols, ch, vec![0i16; n])),
+            Depth::CV_32S => DynamicData::I32(Matrix::from_vec(rows, cols, ch, vec![0i32; n])),
+            Depth::CV_32F => DynamicData::F32(Matrix::from_vec(rows, cols, ch, vec![0f32; n])),
+            Depth::CV_64F => DynamicData::F64(Matrix::from_vec(rows, cols, ch, vec![0f64; n])),
+            Depth::CV_16F => {
+                return Err(PureCvError::InvalidInput(
+                    "CV_16F is not yet supported".into(),
+                ))
+            }
+        };
+        Ok(Self { data })
+    }
+
+    /// Creates a zero-filled matrix using a `MatType`.
+    /// Explicit alias for [`new`] — mirrors OpenCV's `Mat::zeros(rows, cols, type)`.
+    pub fn zeros(rows: usize, cols: usize, mat_type: MatType) -> Result<Self> {
+        Self::new(rows, cols, mat_type)
+    }
+
+    /// Creates a matrix filled with ones using a `MatType`.
+    /// Mirrors OpenCV's `Mat::ones(rows, cols, type)`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `CV_16F` is requested (not yet supported).
+    pub fn ones(rows: usize, cols: usize, mat_type: MatType) -> Result<Self> {
+        let ch = mat_type.channels();
+        let n = rows * cols * ch;
+        let data = match mat_type.depth() {
+            Depth::CV_8U => DynamicData::U8(Matrix::from_vec(rows, cols, ch, vec![1u8; n])),
+            Depth::CV_8S => DynamicData::I8(Matrix::from_vec(rows, cols, ch, vec![1i8; n])),
+            Depth::CV_16U => DynamicData::U16(Matrix::from_vec(rows, cols, ch, vec![1u16; n])),
+            Depth::CV_16S => DynamicData::I16(Matrix::from_vec(rows, cols, ch, vec![1i16; n])),
+            Depth::CV_32S => DynamicData::I32(Matrix::from_vec(rows, cols, ch, vec![1i32; n])),
+            Depth::CV_32F => DynamicData::F32(Matrix::from_vec(rows, cols, ch, vec![1f32; n])),
+            Depth::CV_64F => DynamicData::F64(Matrix::from_vec(rows, cols, ch, vec![1f64; n])),
+            Depth::CV_16F => {
+                return Err(PureCvError::InvalidInput(
+                    "CV_16F is not yet supported".into(),
+                ))
+            }
+        };
+        Ok(Self { data })
+    }
+
+    // -- Typed constructors (from existing Vec<T>) ----------------------------
+
+    /// Creates a `DynamicMatrix` from an existing `Vec<u8>`.
+    ///
+    /// Use this when you already have pixel data in hand (e.g. from a decoder or
+    /// a JS `Uint8Array`). The data is not copied — ownership is transferred.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_u8(rows: usize, cols: usize, channels: usize, data: Vec<u8>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::U8(mat),
+            data: DynamicData::U8(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
 
+    /// Creates a `DynamicMatrix` from an existing `Vec<i8>`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_i8(rows: usize, cols: usize, channels: usize, data: Vec<i8>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::I8(mat),
+            data: DynamicData::I8(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
 
+    /// Creates a `DynamicMatrix` from an existing `Vec<u16>`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_u16(rows: usize, cols: usize, channels: usize, data: Vec<u16>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::U16(mat),
+            data: DynamicData::U16(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
 
+    /// Creates a `DynamicMatrix` from an existing `Vec<i16>`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_i16(rows: usize, cols: usize, channels: usize, data: Vec<i16>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::I16(mat),
+            data: DynamicData::I16(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
 
+    /// Creates a `DynamicMatrix` from an existing `Vec<i32>`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_i32(rows: usize, cols: usize, channels: usize, data: Vec<i32>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::I32(mat),
+            data: DynamicData::I32(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
 
+    /// Creates a `DynamicMatrix` from an existing `Vec<f32>`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_f32(rows: usize, cols: usize, channels: usize, data: Vec<f32>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::F32(mat),
+            data: DynamicData::F32(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
 
+    /// Creates a `DynamicMatrix` from an existing `Vec<f64>`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if `data.len() != rows * cols * channels`.
     pub fn new_f64(rows: usize, cols: usize, channels: usize, data: Vec<f64>) -> Result<Self> {
-        let mat = Matrix::from_vec(rows, cols, channels, data);
+        let expected = rows * cols * channels;
+        if data.len() != expected {
+            return Err(PureCvError::InvalidInput(format!(
+                "Data length {} does not match {}×{}×{} = {}",
+                data.len(),
+                rows,
+                cols,
+                channels,
+                expected
+            )));
+        }
         Ok(Self {
-            data: DynamicData::F64(mat),
+            data: DynamicData::F64(Matrix::from_vec(rows, cols, channels, data)),
         })
     }
+
+    // -- Dimension accessors --------------------------------------------------
 
     pub fn rows(&self) -> usize {
         dispatch_dynamic!(&self.data, mat => mat.rows)
@@ -131,6 +304,19 @@ impl DynamicMatrix {
 
     pub fn channels(&self) -> usize {
         dispatch_dynamic!(&self.data, mat => mat.channels)
+    }
+
+    /// Returns the `MatType` of this matrix (encodes depth + channels).
+    pub fn mat_type(&self) -> MatType {
+        match &self.data {
+            DynamicData::U8(m) => MatType::new(Depth::CV_8U, m.channels),
+            DynamicData::I8(m) => MatType::new(Depth::CV_8S, m.channels),
+            DynamicData::U16(m) => MatType::new(Depth::CV_16U, m.channels),
+            DynamicData::I16(m) => MatType::new(Depth::CV_16S, m.channels),
+            DynamicData::I32(m) => MatType::new(Depth::CV_32S, m.channels),
+            DynamicData::F32(m) => MatType::new(Depth::CV_32F, m.channels),
+            DynamicData::F64(m) => MatType::new(Depth::CV_64F, m.channels),
+        }
     }
 
     /// Returns a human-readable name of the element depth (e.g. `"u8"`, `"f32"`).
@@ -214,7 +400,9 @@ impl DynamicMatrix {
 
     // -- Type conversion -----------------------------------------------------
 
-    /// Creates a new DynamicMatrix with a different element depth.
+    /// Creates a new `DynamicMatrix` with a different element depth.
+    ///
+    /// `depth` is a string: `"u8"`, `"i8"`, `"u16"`, `"i16"`, `"i32"`, `"f32"`, `"f64"`.
     pub fn convert_to(&self, depth: &str) -> Result<DynamicMatrix> {
         macro_rules! convert_inner {
             ($src_mat:expr, $depth:expr) => {

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -34,6 +34,7 @@
  *
  */
 use crate::core::error::{PureCvError, Result};
+use crate::core::types::Scalar;
 
 /// Matrix depth: number of bits per element and its signedness/type.
 /// Follows OpenCV's depth conventions (CV_8U, CV_32F, etc.).
@@ -377,6 +378,69 @@ impl<T: Default + Clone> Matrix<T> {
         self.create(rows, cols, mat_type.channels());
     }
 
+    /// Creates a new `Matrix` with all pixels initialised to the given `Scalar`.
+    ///
+    /// Channels beyond 4 are set to `T::default()` (zero), mirroring OpenCV.
+    pub fn new_with_scalar(rows: usize, cols: usize, channels: usize, s: Scalar<T>) -> Self {
+        let mut data = Vec::with_capacity(rows * cols * channels);
+        for _ in 0..rows * cols {
+            for c in 0..channels {
+                data.push(s.v.get(c).cloned().unwrap_or_default());
+            }
+        }
+        Self {
+            rows,
+            cols,
+            channels,
+            data,
+        }
+    }
+
+    /// Creates a new `Matrix` from a `Size` with all pixels set to `s`.
+    pub fn new_with_scalar_from_size<U: Into<usize>>(
+        size: crate::core::Size<U>,
+        channels: usize,
+        s: Scalar<T>,
+    ) -> Self {
+        Self::new_with_scalar(size.height.into(), size.width.into(), channels, s)
+    }
+
+    /// Sets every pixel in this matrix to the values in `s`.
+    ///
+    /// Channels beyond 4 are set to `T::default()`.
+    pub fn set_to(&mut self, s: Scalar<T>) {
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                for c in 0..self.channels {
+                    self.set(row, col, c, s.v.get(c).cloned().unwrap_or_default());
+                }
+            }
+        }
+    }
+
+    /// Sets pixels to `s` where `mask` is non-zero.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidDimensions` if the mask rows/cols differ from this matrix.
+    pub fn set_to_masked(&mut self, s: Scalar<T>, mask: &Matrix<u8>) -> Result<()> {
+        if self.rows != mask.rows || self.cols != mask.cols {
+            return Err(PureCvError::InvalidDimensions(format!(
+                "mask {}×{} does not match matrix {}×{}",
+                mask.rows, mask.cols, self.rows, self.cols
+            )));
+        }
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                if *mask.get(row, col, 0).unwrap_or(&0) != 0 {
+                    for c in 0..self.channels {
+                        self.set(row, col, c, s.v.get(c).cloned().unwrap_or_default());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Converts the matrix elements to a different type `U`.
     /// Similar to OpenCV's `Mat::convertTo`.
     ///
@@ -481,6 +545,34 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
             mat.set(i, i, 0, val.clone());
         }
         mat
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Scalar constructors that require DataType (fallible, typed)
+// ──────────────────────────────────────────────────────────────────────────────
+
+impl<T: Default + Clone + DataType> Matrix<T> {
+    /// Creates a new `Matrix` from a `Size` and `MatType` with all pixels set to `s`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if the depth encoded in `mat_type` does not
+    /// match the element type `T`.
+    pub fn new_with_scalar_typed_from_size<U: Into<usize>>(
+        size: crate::core::Size<U>,
+        mat_type: MatType,
+        s: Scalar<T>,
+    ) -> Result<Self> {
+        if mat_type.depth() != T::depth() {
+            return Err(PureCvError::InvalidInput(format!(
+                "MatType depth {:?} does not match element type depth {:?}",
+                mat_type.depth(),
+                T::depth()
+            )));
+        }
+        let rows = size.height.into();
+        let cols = size.width.into();
+        Ok(Self::new_with_scalar(rows, cols, mat_type.channels(), s))
     }
 }
 

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -394,9 +394,24 @@ impl<T: Default + Clone> Matrix<T> {
         Ok(())
     }
 
-    /// Creates a new `Matrix` with all pixels initialised to the given `Scalar`.
+    /// Creates a new `Matrix` with every pixel initialised to the given [`Scalar`].
     ///
-    /// Channels beyond 4 are set to `T::default()` (zero), mirroring OpenCV.
+    /// Each pixel stores `channels` values; channel `c` is taken from `s[c]`.
+    /// For matrices with more than 4 channels, channels ≥ 4 are filled with
+    /// `T::default()` (i.e. zero), matching OpenCV's behaviour.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar};
+    /// // 2×3 single-channel matrix filled with 7.0
+    /// let m = Matrix::<f32>::new_with_scalar(2, 3, 1, Scalar::all(7.0));
+    /// assert_eq!(m.get(0, 0, 0), Some(&7.0_f32));
+    ///
+    /// // 1×1 BGR matrix filled with blue (255, 0, 0)
+    /// let blue = Matrix::<u8>::new_with_scalar(1, 1, 3, Scalar::new(255, 0, 0, 0));
+    /// assert_eq!(blue.get(0, 0, 0), Some(&255_u8));
+    /// assert_eq!(blue.get(0, 0, 1), Some(&0_u8));
+    /// ```
     pub fn new_with_scalar(rows: usize, cols: usize, channels: usize, s: Scalar<T>) -> Self {
         let mut data = Vec::with_capacity(rows * cols * channels);
         for _ in 0..rows * cols {
@@ -412,7 +427,19 @@ impl<T: Default + Clone> Matrix<T> {
         }
     }
 
-    /// Creates a new `Matrix` from a `Size` with all pixels set to `s`.
+    /// Creates a new `Matrix` from a [`Size`] with every pixel initialised to `s`.
+    ///
+    /// Convenience wrapper around [`new_with_scalar`](Self::new_with_scalar) that
+    /// accepts a `Size<U>` instead of separate `rows`/`cols` arguments.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar, Size};
+    /// let size = Size::new(640_usize, 480_usize);
+    /// let m = Matrix::<f32>::new_with_scalar_from_size(size, 1, Scalar::all(1.0));
+    /// assert_eq!(m.rows, 480);
+    /// assert_eq!(m.cols, 640);
+    /// ```
     pub fn new_with_scalar_from_size<U: Into<usize>>(
         size: crate::core::Size<U>,
         channels: usize,
@@ -421,9 +448,19 @@ impl<T: Default + Clone> Matrix<T> {
         Self::new_with_scalar(size.height.into(), size.width.into(), channels, s)
     }
 
-    /// Sets every pixel in this matrix to the values in `s`.
+    /// Overwrites every pixel in this matrix with the channel values from `s`.
     ///
-    /// Channels beyond 4 are set to `T::default()`.
+    /// For matrices with more than 4 channels, channels ≥ 4 are set to
+    /// `T::default()` (zero).  Equivalent to OpenCV's `Mat::setTo(scalar)`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar};
+    /// let mut m = Matrix::<u8>::zeros(4, 4, 3);
+    /// m.set_to(Scalar::new(255, 128, 0, 0)); // fill every pixel with (R=255, G=128, B=0)
+    /// assert_eq!(m.get(2, 2, 0), Some(&255_u8));
+    /// assert_eq!(m.get(2, 2, 1), Some(&128_u8));
+    /// ```
     pub fn set_to(&mut self, s: Scalar<T>) {
         for row in 0..self.rows {
             for col in 0..self.cols {
@@ -434,10 +471,27 @@ impl<T: Default + Clone> Matrix<T> {
         }
     }
 
-    /// Sets pixels to `s` where `mask` is non-zero.
+    /// Overwrites pixels with `s` at every position where `mask` is non-zero.
+    ///
+    /// Pixels where `mask == 0` are left unchanged.  This mirrors
+    /// OpenCV's `Mat::setTo(scalar, mask)`.
+    ///
+    /// Channels beyond 4 are set to `T::default()` (zero).
     ///
     /// # Errors
-    /// Returns `PureCvError::InvalidDimensions` if the mask rows/cols differ from this matrix.
+    /// Returns [`PureCvError::InvalidDimensions`] if `mask` does not have the
+    /// same number of rows and columns as `self`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar};
+    /// let mut m = Matrix::<u8>::zeros(2, 2, 1);
+    /// // mask: only top-left pixel is set
+    /// let mask = Matrix::from_vec(2, 2, 1, vec![1u8, 0, 0, 0]);
+    /// m.set_to_masked(Scalar::all(42), &mask).unwrap();
+    /// assert_eq!(m.get(0, 0, 0), Some(&42_u8));
+    /// assert_eq!(m.get(0, 1, 0), Some(&0_u8));  // unchanged
+    /// ```
     pub fn set_to_masked(&mut self, s: Scalar<T>, mask: &Matrix<u8>) -> Result<()> {
         if self.rows != mask.rows || self.cols != mask.cols {
             return Err(PureCvError::InvalidDimensions(format!(
@@ -573,11 +627,28 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
 // ──────────────────────────────────────────────────────────────────────────────
 
 impl<T: Default + Clone + DataType> Matrix<T> {
-    /// Creates a new `Matrix` from a `Size` and `MatType` with all pixels set to `s`.
+    /// Creates a new `Matrix` from a [`Size`] and [`MatType`] with every pixel set to `s`.
+    ///
+    /// The number of channels is taken from `mat_type.channels()`.  This is the
+    /// type-safe variant: the element depth encoded in `mat_type` must match the
+    /// concrete element type `T`; otherwise an error is returned so that
+    /// mismatches are caught at runtime rather than producing silent garbage.
     ///
     /// # Errors
-    /// Returns `PureCvError::InvalidInput` if the depth encoded in `mat_type` does not
-    /// match the element type `T`.
+    /// Returns [`PureCvError::InvalidInput`] when `mat_type.depth() != T::depth()`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar, Size, CV_32FC3};
+    /// let size = Size::new(320_usize, 240_usize);
+    /// let m = Matrix::<f32>::new_with_scalar_typed_from_size(
+    ///     size,
+    ///     CV_32FC3,
+    ///     Scalar::new(1.0, 0.5, 0.0, 0.0),
+    /// )
+    /// .unwrap();
+    /// assert_eq!(m.channels, 3);
+    /// ```
     pub fn new_with_scalar_typed_from_size<U: Into<usize>>(
         size: crate::core::Size<U>,
         mat_type: MatType,

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -378,9 +378,24 @@ impl<T: Default + Clone> Matrix<T> {
         self.create(rows, cols, mat_type.channels());
     }
 
-    /// Creates a new `Matrix` with all pixels initialised to the given `Scalar`.
+    /// Creates a new `Matrix` with every pixel initialised to the given [`Scalar`].
     ///
-    /// Channels beyond 4 are set to `T::default()` (zero), mirroring OpenCV.
+    /// Each pixel stores `channels` values; channel `c` is taken from `s[c]`.
+    /// For matrices with more than 4 channels, channels ≥ 4 are filled with
+    /// `T::default()` (i.e. zero), matching OpenCV's behaviour.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar};
+    /// // 2×3 single-channel matrix filled with 7.0
+    /// let m = Matrix::<f32>::new_with_scalar(2, 3, 1, Scalar::all(7.0));
+    /// assert_eq!(m.get(0, 0, 0), Some(&7.0_f32));
+    ///
+    /// // 1×1 BGR matrix filled with blue (255, 0, 0)
+    /// let blue = Matrix::<u8>::new_with_scalar(1, 1, 3, Scalar::new(255, 0, 0, 0));
+    /// assert_eq!(blue.get(0, 0, 0), Some(&255_u8));
+    /// assert_eq!(blue.get(0, 0, 1), Some(&0_u8));
+    /// ```
     pub fn new_with_scalar(rows: usize, cols: usize, channels: usize, s: Scalar<T>) -> Self {
         let mut data = Vec::with_capacity(rows * cols * channels);
         for _ in 0..rows * cols {
@@ -396,7 +411,19 @@ impl<T: Default + Clone> Matrix<T> {
         }
     }
 
-    /// Creates a new `Matrix` from a `Size` with all pixels set to `s`.
+    /// Creates a new `Matrix` from a [`Size`] with every pixel initialised to `s`.
+    ///
+    /// Convenience wrapper around [`new_with_scalar`](Self::new_with_scalar) that
+    /// accepts a `Size<U>` instead of separate `rows`/`cols` arguments.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar, Size};
+    /// let size = Size::new(640_usize, 480_usize);
+    /// let m = Matrix::<f32>::new_with_scalar_from_size(size, 1, Scalar::all(1.0));
+    /// assert_eq!(m.rows, 480);
+    /// assert_eq!(m.cols, 640);
+    /// ```
     pub fn new_with_scalar_from_size<U: Into<usize>>(
         size: crate::core::Size<U>,
         channels: usize,
@@ -405,9 +432,19 @@ impl<T: Default + Clone> Matrix<T> {
         Self::new_with_scalar(size.height.into(), size.width.into(), channels, s)
     }
 
-    /// Sets every pixel in this matrix to the values in `s`.
+    /// Overwrites every pixel in this matrix with the channel values from `s`.
     ///
-    /// Channels beyond 4 are set to `T::default()`.
+    /// For matrices with more than 4 channels, channels ≥ 4 are set to
+    /// `T::default()` (zero).  Equivalent to OpenCV's `Mat::setTo(scalar)`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar};
+    /// let mut m = Matrix::<u8>::zeros(4, 4, 3);
+    /// m.set_to(Scalar::new(255, 128, 0, 0)); // fill every pixel with (R=255, G=128, B=0)
+    /// assert_eq!(m.get(2, 2, 0), Some(&255_u8));
+    /// assert_eq!(m.get(2, 2, 1), Some(&128_u8));
+    /// ```
     pub fn set_to(&mut self, s: Scalar<T>) {
         for row in 0..self.rows {
             for col in 0..self.cols {
@@ -418,10 +455,27 @@ impl<T: Default + Clone> Matrix<T> {
         }
     }
 
-    /// Sets pixels to `s` where `mask` is non-zero.
+    /// Overwrites pixels with `s` at every position where `mask` is non-zero.
+    ///
+    /// Pixels where `mask == 0` are left unchanged.  This mirrors
+    /// OpenCV's `Mat::setTo(scalar, mask)`.
+    ///
+    /// Channels beyond 4 are set to `T::default()` (zero).
     ///
     /// # Errors
-    /// Returns `PureCvError::InvalidDimensions` if the mask rows/cols differ from this matrix.
+    /// Returns [`PureCvError::InvalidDimensions`] if `mask` does not have the
+    /// same number of rows and columns as `self`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar};
+    /// let mut m = Matrix::<u8>::zeros(2, 2, 1);
+    /// // mask: only top-left pixel is set
+    /// let mask = Matrix::from_vec(2, 2, 1, vec![1u8, 0, 0, 0]);
+    /// m.set_to_masked(Scalar::all(42), &mask).unwrap();
+    /// assert_eq!(m.get(0, 0, 0), Some(&42_u8));
+    /// assert_eq!(m.get(0, 1, 0), Some(&0_u8));  // unchanged
+    /// ```
     pub fn set_to_masked(&mut self, s: Scalar<T>, mask: &Matrix<u8>) -> Result<()> {
         if self.rows != mask.rows || self.cols != mask.cols {
             return Err(PureCvError::InvalidDimensions(format!(
@@ -553,11 +607,28 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
 // ──────────────────────────────────────────────────────────────────────────────
 
 impl<T: Default + Clone + DataType> Matrix<T> {
-    /// Creates a new `Matrix` from a `Size` and `MatType` with all pixels set to `s`.
+    /// Creates a new `Matrix` from a [`Size`] and [`MatType`] with every pixel set to `s`.
+    ///
+    /// The number of channels is taken from `mat_type.channels()`.  This is the
+    /// type-safe variant: the element depth encoded in `mat_type` must match the
+    /// concrete element type `T`; otherwise an error is returned so that
+    /// mismatches are caught at runtime rather than producing silent garbage.
     ///
     /// # Errors
-    /// Returns `PureCvError::InvalidInput` if the depth encoded in `mat_type` does not
-    /// match the element type `T`.
+    /// Returns [`PureCvError::InvalidInput`] when `mat_type.depth() != T::depth()`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::{Matrix, Scalar, Size, CV_32FC3};
+    /// let size = Size::new(320_usize, 240_usize);
+    /// let m = Matrix::<f32>::new_with_scalar_typed_from_size(
+    ///     size,
+    ///     CV_32FC3,
+    ///     Scalar::new(1.0, 0.5, 0.0, 0.0),
+    /// )
+    /// .unwrap();
+    /// assert_eq!(m.channels, 3);
+    /// ```
     pub fn new_with_scalar_typed_from_size<U: Into<usize>>(
         size: crate::core::Size<U>,
         mat_type: MatType,

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -34,6 +34,7 @@
  *
  */
 use crate::core::error::{PureCvError, Result};
+use crate::core::types::Scalar;
 
 /// Matrix depth: number of bits per element and its signedness/type.
 /// Follows OpenCV's depth conventions (CV_8U, CV_32F, etc.).
@@ -393,6 +394,69 @@ impl<T: Default + Clone> Matrix<T> {
         Ok(())
     }
 
+    /// Creates a new `Matrix` with all pixels initialised to the given `Scalar`.
+    ///
+    /// Channels beyond 4 are set to `T::default()` (zero), mirroring OpenCV.
+    pub fn new_with_scalar(rows: usize, cols: usize, channels: usize, s: Scalar<T>) -> Self {
+        let mut data = Vec::with_capacity(rows * cols * channels);
+        for _ in 0..rows * cols {
+            for c in 0..channels {
+                data.push(s.v.get(c).cloned().unwrap_or_default());
+            }
+        }
+        Self {
+            rows,
+            cols,
+            channels,
+            data,
+        }
+    }
+
+    /// Creates a new `Matrix` from a `Size` with all pixels set to `s`.
+    pub fn new_with_scalar_from_size<U: Into<usize>>(
+        size: crate::core::Size<U>,
+        channels: usize,
+        s: Scalar<T>,
+    ) -> Self {
+        Self::new_with_scalar(size.height.into(), size.width.into(), channels, s)
+    }
+
+    /// Sets every pixel in this matrix to the values in `s`.
+    ///
+    /// Channels beyond 4 are set to `T::default()`.
+    pub fn set_to(&mut self, s: Scalar<T>) {
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                for c in 0..self.channels {
+                    self.set(row, col, c, s.v.get(c).cloned().unwrap_or_default());
+                }
+            }
+        }
+    }
+
+    /// Sets pixels to `s` where `mask` is non-zero.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidDimensions` if the mask rows/cols differ from this matrix.
+    pub fn set_to_masked(&mut self, s: Scalar<T>, mask: &Matrix<u8>) -> Result<()> {
+        if self.rows != mask.rows || self.cols != mask.cols {
+            return Err(PureCvError::InvalidDimensions(format!(
+                "mask {}×{} does not match matrix {}×{}",
+                mask.rows, mask.cols, self.rows, self.cols
+            )));
+        }
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                if *mask.get(row, col, 0).unwrap_or(&0) != 0 {
+                    for c in 0..self.channels {
+                        self.set(row, col, c, s.v.get(c).cloned().unwrap_or_default());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Converts the matrix elements to a different type `U`.
     /// Similar to OpenCV's `Mat::convertTo`.
     ///
@@ -501,6 +565,34 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
             mat.set(i, i, 0, val.clone());
         }
         mat
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Scalar constructors that require DataType (fallible, typed)
+// ──────────────────────────────────────────────────────────────────────────────
+
+impl<T: Default + Clone + DataType> Matrix<T> {
+    /// Creates a new `Matrix` from a `Size` and `MatType` with all pixels set to `s`.
+    ///
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if the depth encoded in `mat_type` does not
+    /// match the element type `T`.
+    pub fn new_with_scalar_typed_from_size<U: Into<usize>>(
+        size: crate::core::Size<U>,
+        mat_type: MatType,
+        s: Scalar<T>,
+    ) -> Result<Self> {
+        if mat_type.depth() != T::depth() {
+            return Err(PureCvError::InvalidInput(format!(
+                "MatType depth {:?} does not match element type depth {:?}",
+                mat_type.depth(),
+                T::depth()
+            )));
+        }
+        let rows = size.height.into();
+        let cols = size.width.into();
+        Ok(Self::new_with_scalar(rows, cols, mat_type.channels(), s))
     }
 }
 

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -250,6 +250,9 @@ impl<T: Default + Clone> Matrix<T> {
     /// Safely retrieves a reference to a specific pixel's channel value.
     #[inline]
     pub fn get(&self, row: usize, col: usize, channel: usize) -> Option<&T> {
+        if row >= self.rows || col >= self.cols || channel >= self.channels {
+            return None;
+        }
         let idx = self.flat_index(row, col, channel);
         self.data.get(idx)
     }
@@ -266,6 +269,9 @@ impl<T: Default + Clone> Matrix<T> {
     /// Safely retrieves a mutable reference to a specific pixel's channel value.
     #[inline]
     pub fn get_mut(&mut self, row: usize, col: usize, channel: usize) -> Option<&mut T> {
+        if row >= self.rows || col >= self.cols || channel >= self.channels {
+            return None;
+        }
         let idx = self.flat_index(row, col, channel);
         self.data.get_mut(idx)
     }
@@ -282,6 +288,9 @@ impl<T: Default + Clone> Matrix<T> {
     /// Sets a pixel's channel value using usize indices.
     #[inline]
     pub fn set(&mut self, row: usize, col: usize, channel: usize, value: T) {
+        if row >= self.rows || col >= self.cols || channel >= self.channels {
+            return;
+        }
         let idx = self.flat_index(row, col, channel);
         if let Some(p) = self.data.get_mut(idx) {
             *p = value;

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -320,18 +320,21 @@ impl<T: Default + Clone> Matrix<T> {
 
     /// Creates a new `Matrix` with a specific `MatType`.
     ///
-    /// # Panics
-    /// Panics if the depth of `mat_type` does not match `T`.
-    pub fn new_with_type(rows: usize, cols: usize, mat_type: MatType) -> Self
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if the depth of `mat_type`
+    /// does not match the element type `T`.
+    pub fn new_with_type(rows: usize, cols: usize, mat_type: MatType) -> Result<Self>
     where
         T: Default + Clone + DataType,
     {
-        assert_eq!(
-            mat_type.depth(),
-            T::depth(),
-            "MatType depth must match matrix element type"
-        );
-        Self::new(rows, cols, mat_type.channels())
+        if mat_type.depth() != T::depth() {
+            return Err(PureCvError::InvalidInput(format!(
+                "MatType depth {:?} does not match element type {:?}",
+                mat_type.depth(),
+                T::depth()
+            )));
+        }
+        Ok(Self::new(rows, cols, mat_type.channels()))
     }
 
     /// Returns the number of channels.
@@ -363,18 +366,22 @@ impl<T: Default + Clone> Matrix<T> {
 
     /// Reallocates the matrix to the specified size and `MatType`.
     ///
-    /// # Panics
-    /// Panics if the depth of `mat_type` does not match `T`.
-    pub fn create_with_type(&mut self, rows: usize, cols: usize, mat_type: MatType)
+    /// # Errors
+    /// Returns `PureCvError::InvalidInput` if the depth of `mat_type`
+    /// does not match the element type `T`.
+    pub fn create_with_type(&mut self, rows: usize, cols: usize, mat_type: MatType) -> Result<()>
     where
         T: Default + Clone + DataType,
     {
-        assert_eq!(
-            mat_type.depth(),
-            T::depth(),
-            "MatType depth must match matrix element type"
-        );
+        if mat_type.depth() != T::depth() {
+            return Err(PureCvError::InvalidInput(format!(
+                "MatType depth {:?} does not match element type {:?}",
+                mat_type.depth(),
+                T::depth()
+            )));
+        }
         self.create(rows, cols, mat_type.channels());
+        Ok(())
     }
 
     /// Converts the matrix elements to a different type `U`.
@@ -435,29 +442,33 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
     }
 
     /// Returns a zero array of the specified size and `MatType`.
-    pub fn zeros_with_type(rows: usize, cols: usize, mat_type: MatType) -> Self
+    pub fn zeros_with_type(rows: usize, cols: usize, mat_type: MatType) -> Result<Self>
     where
         T: DataType,
     {
-        assert_eq!(
-            mat_type.depth(),
-            T::depth(),
-            "MatType depth must match element type"
-        );
-        Self::zeros(rows, cols, mat_type.channels())
+        if mat_type.depth() != T::depth() {
+            return Err(PureCvError::InvalidInput(format!(
+                "MatType depth {:?} does not match element type {:?}",
+                mat_type.depth(),
+                T::depth()
+            )));
+        }
+        Ok(Self::zeros(rows, cols, mat_type.channels()))
     }
 
     /// Returns an array of all 1's of the specified size and `MatType`.
-    pub fn ones_with_type(rows: usize, cols: usize, mat_type: MatType) -> Self
+    pub fn ones_with_type(rows: usize, cols: usize, mat_type: MatType) -> Result<Self>
     where
         T: DataType,
     {
-        assert_eq!(
-            mat_type.depth(),
-            T::depth(),
-            "MatType depth must match element type"
-        );
-        Self::ones(rows, cols, mat_type.channels())
+        if mat_type.depth() != T::depth() {
+            return Err(PureCvError::InvalidInput(format!(
+                "MatType depth {:?} does not match element type {:?}",
+                mat_type.depth(),
+                T::depth()
+            )));
+        }
+        Ok(Self::ones(rows, cols, mat_type.channels()))
     }
 
     /// Returns an identity matrix of the specified size and type.

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -854,4 +854,118 @@ mod tests {
         assert_eq!(mat.channels, 2);
         assert_eq!(mat.data, vec![0u8; 4], "data must be zeroed after resize");
     }
+
+    // ---- Matrix scalar constructor tests ----
+
+    #[test]
+    fn test_matrix_new_with_scalar_1ch() {
+        let s = Scalar::new(42u8, 0u8, 0u8, 0u8);
+        let m = Matrix::new_with_scalar(2, 3, 1, s);
+        assert_eq!(m.rows, 2);
+        assert_eq!(m.cols, 3);
+        assert_eq!(m.channels, 1);
+        assert!(m.data.iter().all(|&v| v == 42));
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_3ch() {
+        let s = Scalar::new(10u8, 20u8, 30u8, 0u8);
+        let m = Matrix::new_with_scalar(1, 2, 3, s);
+        // pixel (0,0): [10,20,30]  pixel (0,1): [10,20,30]
+        assert_eq!(m.data, vec![10, 20, 30, 10, 20, 30]);
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_channels_beyond_4() {
+        let s = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        let m = Matrix::new_with_scalar(1, 1, 6, s);
+        // channels 4 and 5 default to 0
+        assert_eq!(m.data, vec![1, 2, 3, 4, 0, 0]);
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_from_size() {
+        use crate::core::Size;
+        let s = Scalar::new(7u8, 8u8, 9u8, 0u8);
+        let m = Matrix::new_with_scalar_from_size(Size::new(3usize, 2usize), 3, s);
+        assert_eq!(m.rows, 2);
+        assert_eq!(m.cols, 3);
+        assert_eq!(m.channels, 3);
+        assert_eq!(m.data.len(), 2 * 3 * 3);
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_typed_from_size_ok() {
+        use crate::core::matrix::{CV_32FC1, CV_8UC3};
+        use crate::core::Size;
+
+        let s = Scalar::new(128u8, 64u8, 32u8, 0u8);
+        let m =
+            Matrix::<u8>::new_with_scalar_typed_from_size(Size::new(4usize, 4usize), CV_8UC3, s)
+                .unwrap();
+        assert_eq!(m.rows, 4);
+        assert_eq!(m.cols, 4);
+        assert_eq!(m.channels, 3);
+        // spot-check first pixel
+        assert_eq!(m.data[0], 128);
+        assert_eq!(m.data[1], 64);
+        assert_eq!(m.data[2], 32);
+
+        let sf = Scalar::new(1.0f32, 0.0f32, 0.0f32, 0.0f32);
+        let mf =
+            Matrix::<f32>::new_with_scalar_typed_from_size(Size::new(2usize, 2usize), CV_32FC1, sf)
+                .unwrap();
+        assert_eq!(mf.channels, 1);
+        assert!(mf.data.iter().all(|&v| v == 1.0));
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_typed_from_size_depth_mismatch() {
+        use crate::core::matrix::CV_32FC1;
+        use crate::core::Size;
+
+        // u8 matrix but CV_32FC1 (f32 depth) → error
+        let s = Scalar::new(0u8, 0u8, 0u8, 0u8);
+        let result =
+            Matrix::<u8>::new_with_scalar_typed_from_size(Size::new(2usize, 2usize), CV_32FC1, s);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_matrix_set_to() {
+        let mut m = Matrix::<u8>::zeros(2, 2, 3);
+        m.set_to(Scalar::new(10u8, 20u8, 30u8, 0u8));
+        // every pixel should be [10, 20, 30]
+        for i in (0..m.data.len()).step_by(3) {
+            assert_eq!(m.data[i], 10);
+            assert_eq!(m.data[i + 1], 20);
+            assert_eq!(m.data[i + 2], 30);
+        }
+    }
+
+    #[test]
+    fn test_matrix_set_to_masked_ok() {
+        let mut m = Matrix::<u8>::zeros(2, 2, 1);
+        // mask: only (0,0) and (1,1) are non-zero
+        let mask = Matrix::from_vec(2, 2, 1, vec![1u8, 0u8, 0u8, 1u8]);
+        m.set_to_masked(Scalar::new(255u8, 0u8, 0u8, 0u8), &mask)
+            .unwrap();
+        assert_eq!(m.data, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn test_matrix_set_to_masked_size_mismatch() {
+        let mut m = Matrix::<u8>::zeros(3, 3, 1);
+        let mask = Matrix::from_vec(2, 2, 1, vec![1u8, 0u8, 0u8, 1u8]);
+        assert!(m
+            .set_to_masked(Scalar::new(255u8, 0u8, 0u8, 0u8), &mask)
+            .is_err());
+    }
+
+    #[test]
+    fn test_matrix_set_to_f32() {
+        let mut m = Matrix::<f32>::zeros(1, 2, 2);
+        m.set_to(Scalar::new(0.5f32, 1.5f32, 0.0f32, 0.0f32));
+        assert_eq!(m.data, vec![0.5, 1.5, 0.5, 1.5]);
+    }
 }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn test_matrix_new_with_scalar_typed_from_size_ok() {
-        use crate::core::matrix::{CV_8UC3, CV_32FC1};
+        use crate::core::matrix::{CV_32FC1, CV_8UC3};
         use crate::core::Size;
 
         let s = Scalar::new(128u8, 64u8, 32u8, 0u8);
@@ -723,12 +723,9 @@ mod tests {
         assert_eq!(m.data[2], 32);
 
         let sf = Scalar::new(1.0f32, 0.0f32, 0.0f32, 0.0f32);
-        let mf = Matrix::<f32>::new_with_scalar_typed_from_size(
-            Size::new(2usize, 2usize),
-            CV_32FC1,
-            sf,
-        )
-        .unwrap();
+        let mf =
+            Matrix::<f32>::new_with_scalar_typed_from_size(Size::new(2usize, 2usize), CV_32FC1, sf)
+                .unwrap();
         assert_eq!(mf.channels, 1);
         assert!(mf.data.iter().all(|&v| v == 1.0));
     }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -665,4 +665,121 @@ mod tests {
             assert_eq!(labels.data[i], lb);
         }
     }
+
+    // ---- Matrix scalar constructor tests ----
+
+    #[test]
+    fn test_matrix_new_with_scalar_1ch() {
+        let s = Scalar::new(42u8, 0u8, 0u8, 0u8);
+        let m = Matrix::new_with_scalar(2, 3, 1, s);
+        assert_eq!(m.rows, 2);
+        assert_eq!(m.cols, 3);
+        assert_eq!(m.channels, 1);
+        assert!(m.data.iter().all(|&v| v == 42));
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_3ch() {
+        let s = Scalar::new(10u8, 20u8, 30u8, 0u8);
+        let m = Matrix::new_with_scalar(1, 2, 3, s);
+        // pixel (0,0): [10,20,30]  pixel (0,1): [10,20,30]
+        assert_eq!(m.data, vec![10, 20, 30, 10, 20, 30]);
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_channels_beyond_4() {
+        let s = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        let m = Matrix::new_with_scalar(1, 1, 6, s);
+        // channels 4 and 5 default to 0
+        assert_eq!(m.data, vec![1, 2, 3, 4, 0, 0]);
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_from_size() {
+        use crate::core::Size;
+        let s = Scalar::new(7u8, 8u8, 9u8, 0u8);
+        let m = Matrix::new_with_scalar_from_size(Size::new(3usize, 2usize), 3, s);
+        assert_eq!(m.rows, 2);
+        assert_eq!(m.cols, 3);
+        assert_eq!(m.channels, 3);
+        assert_eq!(m.data.len(), 2 * 3 * 3);
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_typed_from_size_ok() {
+        use crate::core::matrix::{CV_8UC3, CV_32FC1};
+        use crate::core::Size;
+
+        let s = Scalar::new(128u8, 64u8, 32u8, 0u8);
+        let m =
+            Matrix::<u8>::new_with_scalar_typed_from_size(Size::new(4usize, 4usize), CV_8UC3, s)
+                .unwrap();
+        assert_eq!(m.rows, 4);
+        assert_eq!(m.cols, 4);
+        assert_eq!(m.channels, 3);
+        // spot-check first pixel
+        assert_eq!(m.data[0], 128);
+        assert_eq!(m.data[1], 64);
+        assert_eq!(m.data[2], 32);
+
+        let sf = Scalar::new(1.0f32, 0.0f32, 0.0f32, 0.0f32);
+        let mf = Matrix::<f32>::new_with_scalar_typed_from_size(
+            Size::new(2usize, 2usize),
+            CV_32FC1,
+            sf,
+        )
+        .unwrap();
+        assert_eq!(mf.channels, 1);
+        assert!(mf.data.iter().all(|&v| v == 1.0));
+    }
+
+    #[test]
+    fn test_matrix_new_with_scalar_typed_from_size_depth_mismatch() {
+        use crate::core::matrix::CV_32FC1;
+        use crate::core::Size;
+
+        // u8 matrix but CV_32FC1 (f32 depth) → error
+        let s = Scalar::new(0u8, 0u8, 0u8, 0u8);
+        let result =
+            Matrix::<u8>::new_with_scalar_typed_from_size(Size::new(2usize, 2usize), CV_32FC1, s);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_matrix_set_to() {
+        let mut m = Matrix::<u8>::zeros(2, 2, 3);
+        m.set_to(Scalar::new(10u8, 20u8, 30u8, 0u8));
+        // every pixel should be [10, 20, 30]
+        for i in (0..m.data.len()).step_by(3) {
+            assert_eq!(m.data[i], 10);
+            assert_eq!(m.data[i + 1], 20);
+            assert_eq!(m.data[i + 2], 30);
+        }
+    }
+
+    #[test]
+    fn test_matrix_set_to_masked_ok() {
+        let mut m = Matrix::<u8>::zeros(2, 2, 1);
+        // mask: only (0,0) and (1,1) are non-zero
+        let mask = Matrix::from_vec(2, 2, 1, vec![1u8, 0u8, 0u8, 1u8]);
+        m.set_to_masked(Scalar::new(255u8, 0u8, 0u8, 0u8), &mask)
+            .unwrap();
+        assert_eq!(m.data, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn test_matrix_set_to_masked_size_mismatch() {
+        let mut m = Matrix::<u8>::zeros(3, 3, 1);
+        let mask = Matrix::from_vec(2, 2, 1, vec![1u8, 0u8, 0u8, 1u8]);
+        assert!(m
+            .set_to_masked(Scalar::new(255u8, 0u8, 0u8, 0u8), &mask)
+            .is_err());
+    }
+
+    #[test]
+    fn test_matrix_set_to_f32() {
+        let mut m = Matrix::<f32>::zeros(1, 2, 2);
+        m.set_to(Scalar::new(0.5f32, 1.5f32, 0.0f32, 0.0f32));
+        assert_eq!(m.data, vec![0.5, 1.5, 0.5, 1.5]);
+    }
 }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -382,7 +382,7 @@ mod tests {
         assert!(o.data.iter().all(|&v| v == 1));
         assert_eq!(o.mat_type(), CV_16SC2);
 
-        // Test error when depth mismatch
+        // Test error when depth mismatch on new_with_type
         let err_res = Matrix::<u8>::new_with_type(10, 20, CV_32FC1);
         assert!(matches!(
             err_res,
@@ -679,5 +679,179 @@ mod tests {
         for i in 3..6 {
             assert_eq!(labels.data[i], lb);
         }
+    }
+
+    // ---- Matrix accessor / mutator tests ----
+
+    #[test]
+    fn test_get_and_get_mut() {
+        let mut mat = Matrix::<u8>::from_vec(
+            2,
+            3,
+            2,
+            vec![10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120],
+        );
+
+        // get: valid indices
+        assert_eq!(mat.get(0, 0, 0), Some(&10u8));
+        assert_eq!(mat.get(0, 2, 1), Some(&60u8));
+        assert_eq!(mat.get(1, 1, 0), Some(&90u8));
+
+        // get: out-of-bounds returns None
+        assert_eq!(mat.get(2, 0, 0), None);
+        assert_eq!(mat.get(0, 3, 0), None);
+        assert_eq!(mat.get(0, 0, 2), None);
+
+        // get_mut: modify a value and verify
+        if let Some(v) = mat.get_mut(1, 2, 1) {
+            *v = 255;
+        }
+        assert_eq!(mat.get(1, 2, 1), Some(&255u8));
+
+        // get_mut: out-of-bounds returns None
+        assert_eq!(mat.get_mut(5, 0, 0), None);
+    }
+
+    #[test]
+    fn test_at_and_at_mut() {
+        let mut mat = Matrix::<u8>::from_vec(2, 2, 1, vec![1, 2, 3, 4]);
+
+        // at: positive valid indices
+        assert_eq!(mat.at(0, 0, 0), Some(&1u8));
+        assert_eq!(mat.at(1, 1, 0), Some(&4u8));
+
+        // at: negative indices must return None
+        assert_eq!(mat.at(-1, 0, 0), None);
+        assert_eq!(mat.at(0, -1, 0), None);
+        assert_eq!(mat.at(-1, -1, 0), None);
+
+        // at: out-of-bounds positive
+        assert_eq!(mat.at(2, 0, 0), None);
+
+        // at_mut: negative indices must return None
+        assert_eq!(mat.at_mut(-1, 0, 0), None);
+        assert_eq!(mat.at_mut(0, -5, 0), None);
+
+        // at_mut: modify a value
+        if let Some(v) = mat.at_mut(0, 1, 0) {
+            *v = 99;
+        }
+        assert_eq!(mat.at(0, 1, 0), Some(&99u8));
+    }
+
+    #[test]
+    fn test_set() {
+        let mut mat = Matrix::<f32>::zeros(3, 3, 1);
+
+        // set a value and verify with get
+        mat.set(1, 2, 0, 3.14);
+        assert_eq!(mat.get(1, 2, 0), Some(&3.14f32));
+
+        // set at out-of-bounds: must be a silent no-op, not a panic
+        mat.set(99, 99, 0, 1.0);
+        // if we get here without panic the test passes
+    }
+
+    #[test]
+    fn test_as_slice_and_as_mut_slice() {
+        let mut mat = Matrix::<u8>::from_vec(2, 2, 1, vec![1, 2, 3, 4]);
+
+        // as_slice: correct length and values
+        let s = mat.as_slice();
+        assert_eq!(s.len(), 4);
+        assert_eq!(s, &[1u8, 2, 3, 4]);
+
+        // as_mut_slice: modify through slice, verify via get
+        let ms = mat.as_mut_slice();
+        ms[0] = 42;
+        assert_eq!(mat.get(0, 0, 0), Some(&42u8));
+    }
+
+    // ---- Constructor variants ----
+
+    #[test]
+    fn test_zeros_from_size_and_ones_from_size() {
+        use crate::core::Size;
+
+        let sz = Size::new(4usize, 3usize); // width=4, height=3
+        let z = Matrix::<f32>::zeros_from_size(sz, 1);
+        assert_eq!(z.rows, 3);
+        assert_eq!(z.cols, 4);
+        assert_eq!(z.channels, 1);
+        assert_eq!(z.data.len(), 12);
+        assert!(z.data.iter().all(|&v| v == 0.0));
+
+        let sz2 = Size::new(2usize, 2usize);
+        let o = Matrix::<u8>::ones_from_size(sz2, 3);
+        assert_eq!(o.rows, 2);
+        assert_eq!(o.cols, 2);
+        assert_eq!(o.channels, 3);
+        assert_eq!(o.data.len(), 12);
+        assert!(o.data.iter().all(|&v| v == 1));
+    }
+
+    // ---- with_type error cases ----
+
+    #[test]
+    fn test_zeros_with_type_error() {
+        // depth mismatch: u8 matrix with f32 MatType
+        let err = Matrix::<u8>::zeros_with_type(4, 4, CV_32FC1);
+        assert!(matches!(
+            err,
+            Err(crate::core::error::PureCvError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn test_ones_with_type_error() {
+        // depth mismatch: f32 matrix with u8 MatType
+        let err = Matrix::<f32>::ones_with_type(4, 4, CV_8UC1);
+        assert!(matches!(
+            err,
+            Err(crate::core::error::PureCvError::InvalidInput(_))
+        ));
+    }
+
+    // ---- dims_match ----
+
+    #[test]
+    fn test_dims_match() {
+        let a = Matrix::<u8>::new(4, 4, 3);
+        let b = Matrix::<u8>::new(4, 4, 3);
+        let c = Matrix::<u8>::new(4, 4, 1);
+        let d = Matrix::<f32>::new(2, 4, 3); // different type, same dims as a
+
+        assert!(a.dims_match(&b));
+
+        // different channels
+        assert!(!a.dims_match(&c));
+
+        // different rows — Matrix<f32> vs Matrix<u8>, dims_match is generic over U
+        assert!(!a.dims_match(&d));
+
+        // single-element matrix matches itself
+        let e = Matrix::<i32>::new(1, 1, 1);
+        assert!(e.dims_match(&e.clone()));
+    }
+
+    // ---- create no-op branch ----
+
+    #[test]
+    fn test_create_noop() {
+        let mut mat = Matrix::<u8>::from_vec(2, 3, 1, vec![1, 2, 3, 4, 5, 6]);
+
+        // Calling create with the same dims must not reallocate (data preserved)
+        mat.create(2, 3, 1);
+        assert_eq!(mat.rows, 2);
+        assert_eq!(mat.cols, 3);
+        assert_eq!(mat.channels, 1);
+        assert_eq!(mat.data, vec![1u8, 2, 3, 4, 5, 6], "data must be unchanged");
+
+        // Calling create with different dims resets to default
+        mat.create(1, 2, 2);
+        assert_eq!(mat.rows, 1);
+        assert_eq!(mat.cols, 2);
+        assert_eq!(mat.channels, 2);
+        assert_eq!(mat.data, vec![0u8; 4], "data must be zeroed after resize");
     }
 }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -364,23 +364,38 @@ mod tests {
         assert_eq!(f32::depth(), Depth::CV_32F);
 
         // Test Matrix::new_with_type
-        let mat = Matrix::<u8>::new_with_type(10, 20, CV_8UC3);
+        let mat = Matrix::<u8>::new_with_type(10, 20, CV_8UC3).unwrap();
         assert_eq!(mat.rows, 10);
         assert_eq!(mat.cols, 20);
         assert_eq!(mat.channels, 3);
         assert_eq!(mat.mat_type(), CV_8UC3);
 
         // Test Matrix::zeros_with_type
-        let z = Matrix::<f32>::zeros_with_type(5, 5, CV_32FC1);
+        let z = Matrix::<f32>::zeros_with_type(5, 5, CV_32FC1).unwrap();
         assert_eq!(z.data.len(), 25);
         assert!(z.data.iter().all(|&v| v == 0.0));
         assert_eq!(z.mat_type(), CV_32FC1);
 
         // Test Matrix::ones_with_type
-        let o = Matrix::<i16>::ones_with_type(2, 2, CV_16SC2);
+        let o = Matrix::<i16>::ones_with_type(2, 2, CV_16SC2).unwrap();
         assert_eq!(o.data.len(), 8);
         assert!(o.data.iter().all(|&v| v == 1));
         assert_eq!(o.mat_type(), CV_16SC2);
+
+        // Test error when depth mismatch
+        let err_res = Matrix::<u8>::new_with_type(10, 20, CV_32FC1);
+        assert!(matches!(
+            err_res,
+            Err(crate::core::error::PureCvError::InvalidInput(_))
+        ));
+
+        // Test error when depth mismatch on create_with_type
+        let mut mat = Matrix::<u8>::zeros(1, 1, 1);
+        let err_create = mat.create_with_type(10, 20, CV_32FC1);
+        assert!(matches!(
+            err_create,
+            Err(crate::core::error::PureCvError::InvalidInput(_))
+        ));
     }
 
     #[test]

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -34,7 +34,11 @@
  *
  */
 
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Div, Index, IndexMut, Mul, Sub};
+
+use num_traits::{CheckedDiv, Zero};
+
+use crate::core::error::{PureCvError, Result};
 
 pub type Uchar = u8;
 pub type Schar = i8;
@@ -147,6 +151,285 @@ where
 
     pub fn all(v: T) -> Self {
         Self { v: [v, v, v, v] }
+    }
+
+    /// Creates a `Scalar` from a 4-element array.
+    pub fn from_array(arr: [T; 4]) -> Self {
+        Self { v: arr }
+    }
+
+    /// Returns the underlying 4-element array.
+    pub fn to_array(self) -> [T; 4] {
+        self.v
+    }
+
+    /// Transforms each channel using the given closure, producing a `Scalar<U>`.
+    pub fn map<U, F: Fn(T) -> U>(self, f: F) -> Scalar<U> {
+        Scalar {
+            v: [f(self.v[0]), f(self.v[1]), f(self.v[2]), f(self.v[3])],
+        }
+    }
+}
+
+impl<T> Index<usize> for Scalar<T> {
+    type Output = T;
+    fn index(&self, i: usize) -> &T {
+        &self.v[i]
+    }
+}
+
+impl<T> IndexMut<usize> for Scalar<T> {
+    fn index_mut(&mut self, i: usize) -> &mut T {
+        &mut self.v[i]
+    }
+}
+
+impl<T: Copy + Default> From<[T; 4]> for Scalar<T> {
+    fn from(arr: [T; 4]) -> Self {
+        Self::from_array(arr)
+    }
+}
+
+/// Mirrors OpenCV's `cv::Scalar(v)`: first channel = `v`, rest = zero.
+impl<T: Copy + Default> From<T> for Scalar<T> {
+    fn from(v: T) -> Self {
+        Self::from_value(v)
+    }
+}
+
+impl<T: Copy + Default + Add<Output = T>> Add for Scalar<T> {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self::new(
+            self.v[0] + rhs.v[0],
+            self.v[1] + rhs.v[1],
+            self.v[2] + rhs.v[2],
+            self.v[3] + rhs.v[3],
+        )
+    }
+}
+
+impl<T: Copy + Default + Sub<Output = T>> Sub for Scalar<T> {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(
+            self.v[0] - rhs.v[0],
+            self.v[1] - rhs.v[1],
+            self.v[2] - rhs.v[2],
+            self.v[3] - rhs.v[3],
+        )
+    }
+}
+
+/// Multiplies each channel by a scalar value.
+impl<T: Copy + Default + Mul<Output = T>> Mul<T> for Scalar<T> {
+    type Output = Self;
+    fn mul(self, rhs: T) -> Self {
+        Self::new(
+            self.v[0] * rhs,
+            self.v[1] * rhs,
+            self.v[2] * rhs,
+            self.v[3] * rhs,
+        )
+    }
+}
+
+/// Element-wise multiplication of two `Scalar`s.
+impl<T: Copy + Default + Mul<Output = T>> Mul<Scalar<T>> for Scalar<T> {
+    type Output = Self;
+    fn mul(self, rhs: Scalar<T>) -> Self {
+        Self::new(
+            self.v[0] * rhs.v[0],
+            self.v[1] * rhs.v[1],
+            self.v[2] * rhs.v[2],
+            self.v[3] * rhs.v[3],
+        )
+    }
+}
+
+/// Divides each channel by a scalar value.
+/// Division by zero returns `T::default()` (zero) instead of panicking.
+impl<T: Copy + Default + PartialEq + Zero + Div<Output = T>> Div<T> for Scalar<T> {
+    type Output = Self;
+    fn div(self, rhs: T) -> Self {
+        let safe = |a: T| {
+            if rhs == T::zero() {
+                T::default()
+            } else {
+                a / rhs
+            }
+        };
+        Self {
+            v: [safe(self.v[0]), safe(self.v[1]), safe(self.v[2]), safe(self.v[3])],
+        }
+    }
+}
+
+/// Element-wise division of two `Scalar`s.
+/// Per-channel division by zero returns `T::default()` (zero) instead of panicking.
+impl<T: Copy + Default + PartialEq + Zero + Div<Output = T>> Div<Scalar<T>> for Scalar<T> {
+    type Output = Self;
+    fn div(self, rhs: Scalar<T>) -> Self {
+        let safe = |a: T, b: T| {
+            if b == T::zero() {
+                T::default()
+            } else {
+                a / b
+            }
+        };
+        Self {
+            v: [
+                safe(self.v[0], rhs.v[0]),
+                safe(self.v[1], rhs.v[1]),
+                safe(self.v[2], rhs.v[2]),
+                safe(self.v[3], rhs.v[3]),
+            ],
+        }
+    }
+}
+
+impl<T: Copy + Default + CheckedDiv> Scalar<T> {
+    /// Divides element-wise, returning an error if any divisor channel is zero.
+    /// Available for integer types only (via `num_traits::CheckedDiv`).
+    pub fn checked_div(self, rhs: Scalar<T>) -> Result<Self> {
+        let div_ch = |a: T, b: T, ch: usize| {
+            a.checked_div(&b).ok_or_else(|| {
+                PureCvError::InvalidInput(format!("Division by zero in channel {ch}"))
+            })
+        };
+        Ok(Self {
+            v: [
+                div_ch(self.v[0], rhs.v[0], 0)?,
+                div_ch(self.v[1], rhs.v[1], 1)?,
+                div_ch(self.v[2], rhs.v[2], 2)?,
+                div_ch(self.v[3], rhs.v[3], 3)?,
+            ],
+        })
+    }
+}
+
+#[cfg(test)]
+mod scalar_tests {
+    use super::*;
+
+    #[test]
+    fn test_index() {
+        let s = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        assert_eq!(s[0], 1);
+        assert_eq!(s[3], 4);
+    }
+
+    #[test]
+    fn test_index_mut() {
+        let mut s = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        s[1] = 42;
+        assert_eq!(s[1], 42);
+    }
+
+    #[test]
+    fn test_from_array_method() {
+        let s = Scalar::from_array([10u8, 20u8, 30u8, 40u8]);
+        assert_eq!(s.v, [10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn test_to_array() {
+        let s = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        assert_eq!(s.to_array(), [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_from_t_trait() {
+        let s = Scalar::from(255u8);
+        assert_eq!(s.v, [255, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_from_array_trait() {
+        let s: Scalar<u8> = [10, 20, 30, 40].into();
+        assert_eq!(s.v, [10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn test_map() {
+        let s = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        let s2: Scalar<u16> = s.map(|x| x as u16 * 2);
+        assert_eq!(s2.v, [2u16, 4, 6, 8]);
+    }
+
+    #[test]
+    fn test_add() {
+        let a = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        let b = Scalar::new(10u8, 20u8, 30u8, 40u8);
+        assert_eq!((a + b).v, [11, 22, 33, 44]);
+    }
+
+    #[test]
+    fn test_sub() {
+        let a = Scalar::new(10u8, 20u8, 30u8, 40u8);
+        let b = Scalar::new(1u8, 2u8, 3u8, 4u8);
+        assert_eq!((a - b).v, [9, 18, 27, 36]);
+    }
+
+    #[test]
+    fn test_mul_t() {
+        let s = Scalar::new(10u8, 20u8, 30u8, 40u8);
+        assert_eq!((s * 2u8).v, [20, 40, 60, 80]);
+    }
+
+    #[test]
+    fn test_mul_scalar() {
+        let a = Scalar::new(2u8, 3u8, 4u8, 5u8);
+        let b = Scalar::new(3u8, 2u8, 2u8, 1u8);
+        assert_eq!((a * b).v, [6, 6, 8, 5]);
+    }
+
+    #[test]
+    fn test_div_t() {
+        let s = Scalar::new(20u8, 40u8, 60u8, 80u8);
+        assert_eq!((s / 2u8).v, [10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn test_div_t_by_zero() {
+        let s = Scalar::new(20u8, 40u8, 60u8, 80u8);
+        assert_eq!((s / 0u8).v, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_div_scalar() {
+        let a = Scalar::new(20u8, 40u8, 60u8, 4u8);
+        let b = Scalar::new(2u8, 4u8, 6u8, 2u8);
+        assert_eq!((a / b).v, [10, 10, 10, 2]);
+    }
+
+    #[test]
+    fn test_div_scalar_by_zero_channel() {
+        let a = Scalar::new(20u8, 40u8, 60u8, 4u8);
+        let b = Scalar::new(2u8, 0u8, 6u8, 2u8);
+        assert_eq!((a / b).v, [10, 0, 10, 2]);
+    }
+
+    #[test]
+    fn test_checked_div_ok() {
+        let a = Scalar::new(20u8, 40u8, 60u8, 4u8);
+        let b = Scalar::new(2u8, 4u8, 6u8, 2u8);
+        assert_eq!(a.checked_div(b).unwrap().v, [10, 10, 10, 2]);
+    }
+
+    #[test]
+    fn test_checked_div_err() {
+        let a = Scalar::new(20u8, 40u8, 60u8, 4u8);
+        let b = Scalar::new(2u8, 0u8, 6u8, 2u8);
+        assert!(a.checked_div(b).is_err());
+    }
+
+    #[test]
+    fn test_div_f32_by_zero_yields_inf() {
+        let s = Scalar::new(1.0f32, 2.0f32, 3.0f32, 4.0f32);
+        // f32 zero-check: 0.0 == Zero::zero() → returns default (0.0)
+        let r = s / 0.0f32;
+        assert_eq!(r.v, [0.0, 0.0, 0.0, 0.0]);
     }
 }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -125,9 +125,38 @@ pub type Size2i = Size<i32>;
 pub type Size2f = Size<f32>;
 pub type Size2d = Size<f64>;
 
-/// Scalar represents a 4-element vector.
+/// A 4-element value used to represent pixel colours, per-channel constants,
+/// and range bounds — mirroring `cv::Scalar_<T>` in OpenCV.
 ///
-/// It is widely used in OpenCV to pass pixel values and for range checks.
+/// The four components are stored in `v[0..=3]` and correspond to channels
+/// 0–3 (e.g. B, G, R, A for a BGR image).  When a matrix has fewer than 4
+/// channels only the leading `channels` entries are used; the rest are ignored.
+///
+/// # Convenience constructors
+///
+/// | Constructor | Meaning |
+/// |---|---|
+/// | `Scalar::new(v0, v1, v2, v3)` | explicit four-channel value |
+/// | `Scalar::all(v)` | broadcast `v` to all four channels |
+/// | `Scalar::from_value(v)` | `v` in channel 0, zero elsewhere |
+/// | `Scalar::from_array([a, b, c, d])` | from a raw `[T; 4]` |
+/// | `[a, b, c, d].into()` | same, via `From<[T; 4]>` |
+/// | `v.into()` | `from_value(v)` via `From<T>` |
+///
+/// # Example
+/// ```
+/// use purecv::core::Scalar;
+///
+/// let s = Scalar::new(255u8, 128, 0, 255);
+/// assert_eq!(s[0], 255);
+/// assert_eq!(s[3], 255);
+///
+/// let gray = Scalar::all(128u8);
+/// assert_eq!(gray.to_array(), [128, 128, 128, 128]);
+///
+/// let doubled = gray.map(|x| x as u16 * 2);
+/// assert_eq!(doubled[0], 256u16);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Scalar<T> {
     pub v: [T; 4],
@@ -154,16 +183,34 @@ where
     }
 
     /// Creates a `Scalar` from a 4-element array.
+    ///
+    /// Equivalent to the `From<[T; 4]>` impl; prefer the `into()` syntax for
+    /// brevity unless the explicit call improves readability.
     pub fn from_array(arr: [T; 4]) -> Self {
         Self { v: arr }
     }
 
-    /// Returns the underlying 4-element array.
+    /// Returns the underlying 4-element array, consuming `self`.
+    ///
+    /// Useful when you need to pass the raw values to an API that
+    /// does not accept `Scalar`.
     pub fn to_array(self) -> [T; 4] {
         self.v
     }
 
-    /// Transforms each channel using the given closure, producing a `Scalar<U>`.
+    /// Applies `f` to each channel, producing a `Scalar<U>`.
+    ///
+    /// Useful for type conversions or per-channel transformations without
+    /// manually unpacking the array.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::Scalar;
+    /// let s = Scalar::new(0u8, 128u8, 255u8, 0u8);
+    /// // Normalise to [0.0, 1.0]
+    /// let norm: Scalar<f32> = s.map(|x| x as f32 / 255.0);
+    /// assert!((norm[1] - 128.0 / 255.0).abs() < 1e-6);
+    /// ```
     pub fn map<U, F: Fn(T) -> U>(self, f: F) -> Scalar<U> {
         Scalar {
             v: [f(self.v[0]), f(self.v[1]), f(self.v[2]), f(self.v[3])],
@@ -171,6 +218,10 @@ where
     }
 }
 
+/// Accesses channel `i` by index (`s[0]` … `s[3]`).
+///
+/// # Panics
+/// Panics if `i >= 4`.
 impl<T> Index<usize> for Scalar<T> {
     type Output = T;
     fn index(&self, i: usize) -> &T {
@@ -178,25 +229,34 @@ impl<T> Index<usize> for Scalar<T> {
     }
 }
 
+/// Mutably accesses channel `i` by index (`s[0]` … `s[3]`).
+///
+/// # Panics
+/// Panics if `i >= 4`.
 impl<T> IndexMut<usize> for Scalar<T> {
     fn index_mut(&mut self, i: usize) -> &mut T {
         &mut self.v[i]
     }
 }
 
+/// Converts a `[T; 4]` array directly into a `Scalar<T>`.
 impl<T: Copy + Default> From<[T; 4]> for Scalar<T> {
     fn from(arr: [T; 4]) -> Self {
         Self::from_array(arr)
     }
 }
 
-/// Mirrors OpenCV's `cv::Scalar(v)`: first channel = `v`, rest = zero.
+/// Mirrors OpenCV's `cv::Scalar(v)`: channel 0 = `v`, channels 1–3 = zero.
+///
+/// This is the idiomatic way to create a single-channel constant, e.g.
+/// `Scalar::from(128u8)` for a grayscale value.
 impl<T: Copy + Default> From<T> for Scalar<T> {
     fn from(v: T) -> Self {
         Self::from_value(v)
     }
 }
 
+/// Per-channel addition: `result[c] = self[c] + rhs[c]`.
 impl<T: Copy + Default + Add<Output = T>> Add for Scalar<T> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
@@ -209,6 +269,7 @@ impl<T: Copy + Default + Add<Output = T>> Add for Scalar<T> {
     }
 }
 
+/// Per-channel subtraction: `result[c] = self[c] - rhs[c]`.
 impl<T: Copy + Default + Sub<Output = T>> Sub for Scalar<T> {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
@@ -221,7 +282,9 @@ impl<T: Copy + Default + Sub<Output = T>> Sub for Scalar<T> {
     }
 }
 
-/// Multiplies each channel by a scalar value.
+/// Broadcast multiply: scales every channel by the same value `rhs`.
+///
+/// `result[c] = self[c] * rhs`
 impl<T: Copy + Default + Mul<Output = T>> Mul<T> for Scalar<T> {
     type Output = Self;
     fn mul(self, rhs: T) -> Self {
@@ -234,7 +297,7 @@ impl<T: Copy + Default + Mul<Output = T>> Mul<T> for Scalar<T> {
     }
 }
 
-/// Element-wise multiplication of two `Scalar`s.
+/// Element-wise multiply: `result[c] = self[c] * rhs[c]`.
 impl<T: Copy + Default + Mul<Output = T>> Mul<Scalar<T>> for Scalar<T> {
     type Output = Self;
     fn mul(self, rhs: Scalar<T>) -> Self {
@@ -247,8 +310,12 @@ impl<T: Copy + Default + Mul<Output = T>> Mul<Scalar<T>> for Scalar<T> {
     }
 }
 
-/// Divides each channel by a scalar value.
-/// Division by zero returns `T::default()` (zero) instead of panicking.
+/// Broadcast divide: `result[c] = self[c] / rhs`.
+///
+/// **Zero-safe:** if `rhs` is zero every channel is set to `T::default()` (zero)
+/// rather than panicking or producing `NaN`/`Inf`.  For floating-point types
+/// this deviates from IEEE 754; use plain `/` on the raw values if you need
+/// `Inf` semantics.  For checked integer division see [`Scalar::checked_div`].
 impl<T: Copy + Default + PartialEq + Zero + Div<Output = T>> Div<T> for Scalar<T> {
     type Output = Self;
     fn div(self, rhs: T) -> Self {
@@ -260,13 +327,20 @@ impl<T: Copy + Default + PartialEq + Zero + Div<Output = T>> Div<T> for Scalar<T
             }
         };
         Self {
-            v: [safe(self.v[0]), safe(self.v[1]), safe(self.v[2]), safe(self.v[3])],
+            v: [
+                safe(self.v[0]),
+                safe(self.v[1]),
+                safe(self.v[2]),
+                safe(self.v[3]),
+            ],
         }
     }
 }
 
-/// Element-wise division of two `Scalar`s.
-/// Per-channel division by zero returns `T::default()` (zero) instead of panicking.
+/// Element-wise divide: `result[c] = self[c] / rhs[c]`.
+///
+/// **Zero-safe:** any channel whose divisor is zero produces `T::default()` (zero).
+/// For integer types that need an error on division-by-zero use [`Scalar::checked_div`].
 impl<T: Copy + Default + PartialEq + Zero + Div<Output = T>> Div<Scalar<T>> for Scalar<T> {
     type Output = Self;
     fn div(self, rhs: Scalar<T>) -> Self {
@@ -289,8 +363,27 @@ impl<T: Copy + Default + PartialEq + Zero + Div<Output = T>> Div<Scalar<T>> for 
 }
 
 impl<T: Copy + Default + CheckedDiv> Scalar<T> {
-    /// Divides element-wise, returning an error if any divisor channel is zero.
-    /// Available for integer types only (via `num_traits::CheckedDiv`).
+    /// Element-wise division that returns an error instead of zero on
+    /// division-by-zero.
+    ///
+    /// Only available for integer types that implement [`num_traits::CheckedDiv`]
+    /// (e.g. `u8`, `i32`).  For floating-point types use the infallible
+    /// `Div<Scalar<T>>` impl.
+    ///
+    /// # Errors
+    /// Returns [`PureCvError::InvalidInput`] naming the first channel whose
+    /// divisor is zero.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::Scalar;
+    /// let a = Scalar::new(10u8, 20, 30, 40);
+    /// let b = Scalar::new(2u8,  4,  5, 8);
+    /// assert_eq!(a.checked_div(b).unwrap().v, [5, 5, 6, 5]);
+    ///
+    /// let bad = Scalar::new(2u8, 0, 1, 1);
+    /// assert!(a.checked_div(bad).is_err());
+    /// ```
     pub fn checked_div(self, rhs: Scalar<T>) -> Result<Self> {
         let div_ch = |a: T, b: T, ch: usize| {
             a.checked_div(&b).ok_or_else(|| {


### PR DESCRIPTION
## Summary

- Add `Index`/`IndexMut`, `from_array`/`to_array`, `From<[T;4]>`/`From<T>`, and `map()` to `Scalar<T>`
- Add per-channel `Add`/`Sub` and `Mul<T>`/`Mul<Scalar<T>>` arithmetic to `Scalar<T>`
- Add safe `Div<T>`/`Div<Scalar<T>>` (returns zero on div-by-zero) and `checked_div()` returning `Result`
- Add `Matrix::new_with_scalar`, `new_with_scalar_from_size`, `new_with_scalar_typed_from_size`
- Add `Matrix::set_to` and `set_to_masked`; channels beyond 4 default to `T::default()`
- Add comprehensive unit tests for all new `Scalar` and `Matrix` scalar APIs

Closes #21

## Test plan

- [x] `cargo test` passes with all new unit tests for `Scalar` arithmetic, indexing, conversions, and `map()`
- [x] `cargo test` passes for new `Matrix` scalar constructor and `set_to`/`set_to_masked` APIs
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)