### PR TITLE
feat(core): add DFT, LUT, and improve countNonZero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rayon = { version = "1.10", optional = true }
 ndarray = { version = "0.17", optional = true }
 num-traits = "0.2"
 pulp = { version = "0.22", optional = true }
+rustfft = { version = "6", optional = true }
 log = "0.4"
 
 [dev-dependencies]
@@ -30,6 +31,7 @@ std = []
 parallel = ["rayon"]
 ndarray = ["dep:ndarray"]
 simd = ["dep:pulp"]
+fft = ["dep:rustfft"]
 
 [[bench]]
 name = "arithm_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ path = "benches/dft_bench.rs"
 harness = false
 required-features = ["fft"]
 
+[[example]]
+name = "dft_example"
+required-features = ["fft"]
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,12 @@ name = "structural_bench"
 path = "benches/structural_bench.rs"
 harness = false
 
+[[bench]]
+name = "dft_bench"
+path = "benches/dft_bench.rs"
+harness = false
+required-features = ["fft"]
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/benches/arithm_bench.rs
+++ b/benches/arithm_bench.rs
@@ -36,8 +36,8 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use purecv::core::arithm::{
-    absdiff, add, add_weighted, bitwise_and, convert_scale_abs, divide, dot, gemm, magnitude, mean,
-    min, multiply, norm, normalize, sqrt, subtract, sum,
+    absdiff, add, add_weighted, bitwise_and, convert_scale_abs, count_non_zero, divide, dot, gemm,
+    lut, magnitude, mean, min, multiply, norm, normalize, sqrt, subtract, sum,
 };
 use purecv::core::types::NormTypes;
 use purecv::core::Matrix;
@@ -168,6 +168,36 @@ fn bench_arithm(c: &mut Criterion) {
             )
             .unwrap()
         })
+    });
+
+    // --- count_non_zero ---
+    let mut v1_i32 = Matrix::<i32>::new(size, size, 1);
+    for (i, v) in v1_i32.data.iter_mut().enumerate() {
+        *v = if i % 3 == 0 { 0 } else { (i as i32) + 1 };
+    }
+
+    c.bench_function("count_non_zero_1024x1024_i32", |b| {
+        b.iter(|| count_non_zero(black_box(&v1_i32)).unwrap())
+    });
+
+    // --- LUT ---
+    // Build a gamma-correction-style LUT: out = (in/255)^2.2 * 255
+    let lut_data: Vec<u8> = (0..256)
+        .map(|i| ((i as f64 / 255.0).powf(2.2) * 255.0) as u8)
+        .collect();
+    let lut_table = Matrix::from_vec(1, 256, 1, lut_data);
+
+    // Single-channel LUT
+    c.bench_function("lut_1024x1024_u8", |b| {
+        b.iter(|| lut(black_box(&u1), black_box(&lut_table)).unwrap())
+    });
+
+    // 3-channel LUT (broadcast)
+    let mut u3 = Matrix::<u8>::new(size, size, 3);
+    u3.data.fill(128);
+
+    c.bench_function("lut_1024x1024x3_u8_broadcast", |b| {
+        b.iter(|| lut(black_box(&u3), black_box(&lut_table)).unwrap())
     });
 }
 

--- a/benches/benchmark_results.md
+++ b/benches/benchmark_results.md
@@ -9,6 +9,39 @@ This document highlights the performance evaluation of the `purecv` library acro
 
 All tests operate on `1024x1024` image/matrix tensors using `f32` (or `u8` depending on the domain context). Times shown represent the median calculation calculated by `Criterion.rs`.
 
+---
+
+## New Benchmarks — count_non_zero, LUT & DFT
+
+*Execution Date: 2026-03-31 (CET)*
+
+Three new function groups have been benchmarked: `count_non_zero`, `lut` (Look-Up Table), and `dft` (Discrete Fourier Transform via `rustfft`). DFT benchmarks require the `fft` feature flag.
+
+> **Note:** The 4-strategy comparison table (Standard / SIMD Only / Parallel / Parallel+SIMD) does not apply to the LUT and DFT benchmarks below. LUT is a pure table lookup where SIMD provides no benefit, and DFT delegates to `rustfft` which manages its own internal SIMD — the `parallel` and `simd` feature flags have no effect on either. Results shown are with default features (Parallel enabled).
+
+### Arithm — count_non_zero & LUT
+
+| Benchmark / Operation                  | Parallel (default) |
+| :------------------------------------- | :----------------- |
+| `count_non_zero_1024×1024_i32`         | 116.03 µs          |
+| `lut_1024×1024_u8` (1ch)              | 501.25 µs          |
+| `lut_1024×1024×3_u8_broadcast` (3ch)  | 855.86 µs          |
+
+`count_non_zero` is a simple reduction — very fast with rayon parallelism. LUT is a pure table lookup (memory-bound), scaling linearly with channel count (3ch ≈ 1.7× of 1ch).
+
+### DFT — Discrete Fourier Transform (`--features fft`)
+
+| Benchmark / Operation                  | Time        |
+| :------------------------------------- | :---------- |
+| `get_optimal_dft_size`                 | 18.76 ns    |
+| `dft_forward_256×256_f32`              | 454.03 µs   |
+| `dft_inverse_256×256_f32`              | 514.82 µs   |
+| `dft_forward_512×512_f32`              | 3.80 ms     |
+| `dft_forward_1024×1024_f64`            | 28.21 ms    |
+
+DFT scales as O(n² log n) for 2D transforms: 512×512 is ~8× slower than 256×256, consistent with the 4× data increase and logarithmic factor growth. `get_optimal_dft_size` is a trivial binary search (~19 ns).
+
+---
 
 *Execution Date: 2026-03-17 (CET)*
 ---

--- a/benches/dft_bench.rs
+++ b/benches/dft_bench.rs
@@ -1,0 +1,88 @@
+/*
+ *  dft_bench.rs
+ *  purecv
+ *
+ *  This file is part of purecv - OpenCV.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use purecv::core::dft::{dft, get_optimal_dft_size, DFT_COMPLEX_OUTPUT, DFT_INVERSE, DFT_SCALE};
+use purecv::core::Matrix;
+
+fn bench_dft(c: &mut Criterion) {
+    // --- get_optimal_dft_size (pure computation, very fast) ---
+    c.bench_function("get_optimal_dft_size", |b| {
+        b.iter(|| get_optimal_dft_size(black_box(1000)))
+    });
+
+    // --- DFT forward, 256×256 f32 (real input) ---
+    let size_small = 256;
+    let mut src_256 = Matrix::<f32>::new(size_small, size_small, 1);
+    for (i, v) in src_256.data.iter_mut().enumerate() {
+        *v = ((i % size_small) as f32 * 0.1).sin();
+    }
+
+    c.bench_function("dft_forward_256x256_f32", |b| {
+        b.iter(|| dft(black_box(&src_256), DFT_COMPLEX_OUTPUT, 0).unwrap())
+    });
+
+    // --- DFT inverse, 256×256 f32 ---
+    let freq_256 = dft(&src_256, DFT_COMPLEX_OUTPUT, 0).unwrap();
+    c.bench_function("dft_inverse_256x256_f32", |b| {
+        b.iter(|| dft(black_box(&freq_256), DFT_INVERSE | DFT_SCALE, 0).unwrap())
+    });
+
+    // --- DFT forward, 512×512 f32 ---
+    let size_med = 512;
+    let mut src_512 = Matrix::<f32>::new(size_med, size_med, 1);
+    for (i, v) in src_512.data.iter_mut().enumerate() {
+        *v = ((i % size_med) as f32 * 0.1).sin();
+    }
+
+    c.bench_function("dft_forward_512x512_f32", |b| {
+        b.iter(|| dft(black_box(&src_512), DFT_COMPLEX_OUTPUT, 0).unwrap())
+    });
+
+    // --- DFT forward, 1024×1024 f64 ---
+    let size_lg = 1024;
+    let mut src_1024 = Matrix::<f64>::new(size_lg, size_lg, 1);
+    for (i, v) in src_1024.data.iter_mut().enumerate() {
+        *v = ((i % size_lg) as f64 * 0.1).sin();
+    }
+
+    c.bench_function("dft_forward_1024x1024_f64", |b| {
+        b.iter(|| dft(black_box(&src_1024), DFT_COMPLEX_OUTPUT, 0).unwrap())
+    });
+}
+
+criterion_group!(benches, bench_dft);
+criterion_main!(benches);

--- a/examples/dft_example.rs
+++ b/examples/dft_example.rs
@@ -1,0 +1,177 @@
+/*
+ *  dft_example.rs
+ *  purecv
+ *
+ *  This file is part of purecv - OpenCV.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! DFT (Discrete Fourier Transform) example.
+//!
+//! Run with: `cargo run --example dft_example --features fft`
+
+use image::{DynamicImage, GenericImageView, ImageBuffer, Luma};
+use purecv::core::dft::{dft, get_optimal_dft_size, DFT_COMPLEX_OUTPUT};
+use purecv::core::structural::copy_make_border;
+use purecv::core::{normalize, Matrix, NormTypes, Scalar};
+use purecv::imgproc::cvt_color_rgb_to_gray;
+use purecv::version;
+use std::path::Path;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("--- purecv DFT Example ---");
+    println!("purecv v{}", version::get_version());
+
+    // 1. Load the image
+    let img_path = "examples/data/butterfly.jpg";
+    if !Path::new(img_path).exists() {
+        eprintln!("Error: {} not found. Run from the project root.", img_path);
+        return Ok(());
+    }
+
+    let img = image::open(img_path)?;
+    let (width, height) = img.dimensions();
+    println!("Loaded image: {} ({}x{})", img_path, width, height);
+
+    let rgb_img = img.to_rgb8();
+    let mat_rgb = Matrix::from_vec(height as usize, width as usize, 3, rgb_img.into_raw());
+
+    // 2. Convert to grayscale
+    let mat_gray = cvt_color_rgb_to_gray(&mat_rgb).expect("Grayscale conversion failed");
+    println!(
+        "Converted to grayscale: {}x{}",
+        mat_gray.cols, mat_gray.rows
+    );
+
+    // 3. Convert u8 → f32
+    let mat_f32 = Matrix::from_vec(
+        mat_gray.rows,
+        mat_gray.cols,
+        1,
+        mat_gray.data.iter().map(|&v| v as f32).collect(),
+    );
+
+    // 4. Pad to optimal DFT size
+    let opt_rows = get_optimal_dft_size(mat_f32.rows as i32) as usize;
+    let opt_cols = get_optimal_dft_size(mat_f32.cols as i32) as usize;
+    let pad_bottom = opt_rows - mat_f32.rows;
+    let pad_right = opt_cols - mat_f32.cols;
+    println!(
+        "Padding to optimal DFT size: {}x{} → {}x{}",
+        mat_f32.cols, mat_f32.rows, opt_cols, opt_rows
+    );
+
+    let padded = copy_make_border(
+        &mat_f32,
+        0,
+        pad_bottom,
+        0,
+        pad_right,
+        0,
+        Scalar::all(0.0f32),
+    )?;
+
+    // 5. Forward DFT
+    println!("Computing DFT...");
+    let t = Instant::now();
+    let freq = dft(&padded, DFT_COMPLEX_OUTPUT, 0)?;
+    println!("  DFT computed in {:.2?}", t.elapsed());
+    println!(
+        "  Output: {}x{} x {} channels (complex)",
+        freq.cols, freq.rows, freq.channels
+    );
+
+    // 6. Compute magnitude: sqrt(re² + im²)
+    let mut magnitude = Matrix::<f32>::new(freq.rows, freq.cols, 1);
+    for r in 0..freq.rows {
+        for c in 0..freq.cols {
+            let idx = (r * freq.cols + c) * 2;
+            let re = freq.data[idx];
+            let im = freq.data[idx + 1];
+            magnitude.data[r * freq.cols + c] = (re * re + im * im).sqrt();
+        }
+    }
+
+    // 7. Log scale: log(1 + magnitude) for better visualization
+    for v in &mut magnitude.data {
+        *v = (1.0 + *v).ln();
+    }
+
+    // 8. Shift quadrants so DC is at center
+    //    Swap top-left ↔ bottom-right and top-right ↔ bottom-left
+    let cx = magnitude.cols / 2;
+    let cy = magnitude.rows / 2;
+    for r in 0..cy {
+        for c in 0..cx {
+            let tl = r * magnitude.cols + c;
+            let br = (r + cy) * magnitude.cols + (c + cx);
+            magnitude.data.swap(tl, br);
+
+            let tr = r * magnitude.cols + (c + cx);
+            let bl = (r + cy) * magnitude.cols + c;
+            magnitude.data.swap(tr, bl);
+        }
+    }
+
+    // 9. Normalize to 0–255 and convert to u8
+    let mut mag_norm = Matrix::<f32>::new(magnitude.rows, magnitude.cols, 1);
+    normalize(
+        &magnitude,
+        &mut mag_norm,
+        0.0,
+        255.0,
+        NormTypes::MinMax,
+        -1,
+        None,
+    )?;
+    let mag_u8 = Matrix::from_vec(
+        mag_norm.rows,
+        mag_norm.cols,
+        1,
+        mag_norm.data.iter().map(|&v| v as u8).collect(),
+    );
+
+    // 10. Save result
+    std::fs::create_dir_all("examples/data/out")?;
+    save_matrix_gray(&mag_u8, "examples/data/out/dft_magnitude.png")?;
+    println!("  Saved: examples/data/out/dft_magnitude.png");
+
+    println!("\nDFT magnitude spectrum computed successfully!");
+    Ok(())
+}
+
+fn save_matrix_gray(mat: &Matrix<u8>, filename: &str) -> image::ImageResult<()> {
+    let img: ImageBuffer<Luma<u8>, Vec<u8>> =
+        ImageBuffer::from_raw(mat.cols as u32, mat.rows as u32, mat.data.clone())
+            .expect("Failed to create image buffer");
+    DynamicImage::ImageLuma8(img).save(filename)
+}

--- a/examples/lut_example.rs
+++ b/examples/lut_example.rs
@@ -1,0 +1,97 @@
+/*
+ *  lut_example.rs
+ *  purecv
+ *
+ *  This file is part of purecv - OpenCV.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+use image::{DynamicImage, GenericImageView, ImageBuffer, Rgb};
+use purecv::core::lut;
+use purecv::core::Matrix;
+use purecv::version;
+use std::path::Path;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("--- purecv LUT Example ---");
+    println!("purecv v{}", version::get_version());
+
+    // 1. Load the image
+    let img_path = "examples/data/butterfly.jpg";
+    if !Path::new(img_path).exists() {
+        eprintln!("Error: {} not found. Run from the project root.", img_path);
+        return Ok(());
+    }
+
+    let img = image::open(img_path)?;
+    let (width, height) = img.dimensions();
+    println!("Loaded image: {} ({}x{})", img_path, width, height);
+
+    let rgb_img = img.to_rgb8();
+    let mat_rgb = Matrix::from_vec(height as usize, width as usize, 3, rgb_img.into_raw());
+
+    std::fs::create_dir_all("examples/data/out")?;
+
+    // 2. Gamma correction (γ = 1/2.2 — brightens the image)
+    println!("Applying Gamma Correction (γ=1/2.2)...");
+    let gamma_lut_data: Vec<u8> = (0..256)
+        .map(|i| ((i as f64 / 255.0).powf(1.0 / 2.2) * 255.0).round() as u8)
+        .collect();
+    let gamma_table = Matrix::from_vec(1, 256, 1, gamma_lut_data);
+
+    let t = Instant::now();
+    let gamma_result = lut(&mat_rgb, &gamma_table)?;
+    println!("  Done in {:.2?}", t.elapsed());
+    save_matrix_rgb(&gamma_result, "examples/data/out/lut_gamma.png")?;
+    println!("  Saved: examples/data/out/lut_gamma.png");
+
+    // 3. Inversion (negative image)
+    println!("Applying Inversion...");
+    let invert_lut_data: Vec<u8> = (0..256).map(|i| (255 - i) as u8).collect();
+    let invert_table = Matrix::from_vec(1, 256, 1, invert_lut_data);
+
+    let t = Instant::now();
+    let inverted = lut(&mat_rgb, &invert_table)?;
+    println!("  Done in {:.2?}", t.elapsed());
+    save_matrix_rgb(&inverted, "examples/data/out/lut_inverted.png")?;
+    println!("  Saved: examples/data/out/lut_inverted.png");
+
+    println!("\nAll LUT operations applied successfully!");
+    Ok(())
+}
+
+fn save_matrix_rgb(mat: &Matrix<u8>, filename: &str) -> image::ImageResult<()> {
+    let img: ImageBuffer<Rgb<u8>, Vec<u8>> =
+        ImageBuffer::from_raw(mat.cols as u32, mat.rows as u32, mat.data.clone())
+            .expect("Failed to create image buffer");
+    DynamicImage::ImageRgb8(img).save(filename)
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -36,6 +36,8 @@
 
 pub mod arithm;
 pub mod constants;
+#[cfg(feature = "fft")]
+pub mod dft;
 pub mod dynamic;
 pub mod error;
 pub mod matrix;
@@ -56,12 +58,17 @@ mod tests;
 // Re-exports for easier access
 pub use self::arithm::{
     absdiff, add, bitwise_and, bitwise_not, bitwise_or, bitwise_xor, cart_to_polar, check_range,
-    count_non_zero, cross, determinant, divide, dot, gemm, invert, kmeans, magnitude, mean,
+    count_non_zero, cross, determinant, divide, dot, gemm, invert, kmeans, lut, magnitude, mean,
     mean_std_dev, min_max_loc, multiply, norm, normalize, perspective_transform, phase,
     polar_to_cart, reduce, set_identity, solve, solve_poly, sort, sort_idx, subtract, sum, trace,
     transform, DecompTypes, GEMM_1_T, GEMM_2_T, GEMM_3_T,
 };
 pub use self::constants::{CV_2PI, CV_LN2, CV_LOG2, CV_PI, CV_PI_2, CV_PI_4};
+#[cfg(feature = "fft")]
+pub use self::dft::{
+    dft, get_optimal_dft_size, DftFloat, DFT_COMPLEX_OUTPUT, DFT_INVERSE, DFT_REAL_OUTPUT,
+    DFT_ROWS, DFT_SCALE,
+};
 pub use self::dynamic::{DynamicData, DynamicMatrix};
 pub use self::error::{PureCvError, Result};
 pub use self::matrix::{

--- a/src/core/arithm.rs
+++ b/src/core/arithm.rs
@@ -1402,17 +1402,24 @@ where
 }
 
 /// Counts non-zero array elements.
-pub fn count_non_zero<T>(src: &Matrix<T>) -> i32
+///
+/// The input matrix must be single-channel.
+pub fn count_non_zero<T>(src: &Matrix<T>) -> Result<i32>
 where
     T: Num + Copy + Send + Sync + 'static,
 {
+    if src.channels != 1 {
+        return Err(PureCvError::InvalidInput(
+            "countNonZero requires single-channel matrix".into(),
+        ));
+    }
     #[cfg(feature = "parallel")]
     {
-        src.data.par_iter().filter(|&&x| !x.is_zero()).count() as i32
+        Ok(src.data.par_iter().filter(|&&x| !x.is_zero()).count() as i32)
     }
     #[cfg(not(feature = "parallel"))]
     {
-        src.data.iter().filter(|&&x| !x.is_zero()).count() as i32
+        Ok(src.data.iter().filter(|&&x| !x.is_zero()).count() as i32)
     }
 }
 
@@ -3429,6 +3436,80 @@ fn kmeans_pp_init(
         centers[c_idx * dims..(c_idx + 1) * dims]
             .copy_from_slice(&samples[chosen * dims..(chosen + 1) * dims]);
     }
+}
+
+/// Performs a look-up table transform of a matrix.
+///
+/// The source matrix must have `u8` depth. The look-up table must contain
+/// exactly 256 entries. If `lut_table` has one channel it is applied to every
+/// channel of `src`; otherwise the number of channels must match.
+pub fn lut<T>(src: &Matrix<u8>, lut_table: &Matrix<T>) -> Result<Matrix<T>>
+where
+    T: Copy + Clone + Default + Send + Sync + 'static,
+{
+    let lut_entries = lut_table.rows * lut_table.cols;
+    if lut_entries != 256 {
+        return Err(PureCvError::InvalidInput(format!(
+            "LUT must have exactly 256 entries, got {}",
+            lut_entries
+        )));
+    }
+    let lut_cn = lut_table.channels;
+    let src_cn = src.channels;
+    if lut_cn != 1 && lut_cn != src_cn {
+        return Err(PureCvError::IncompatibleChannels(format!(
+            "LUT channels ({}) must be 1 or match source channels ({})",
+            lut_cn, src_cn
+        )));
+    }
+
+    let total = src.rows * src.cols * src_cn;
+    let mut dst_data = vec![T::default(); total];
+    let lut_data = &lut_table.data;
+
+    if lut_cn == 1 {
+        // Broadcast: same LUT for all channels
+        #[cfg(feature = "parallel")]
+        {
+            dst_data
+                .par_iter_mut()
+                .zip(src.data.par_iter())
+                .for_each(|(d, &s)| {
+                    *d = lut_data[s as usize];
+                });
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            for (d, &s) in dst_data.iter_mut().zip(src.data.iter()) {
+                *d = lut_data[s as usize];
+            }
+        }
+    } else {
+        // Per-channel LUT
+        #[cfg(feature = "parallel")]
+        {
+            dst_data.par_iter_mut().enumerate().for_each(|(i, d)| {
+                let ch = i % src_cn;
+                let idx = src.data[i] as usize;
+                *d = lut_data[idx * lut_cn + ch];
+            });
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            for (i, d) in dst_data.iter_mut().enumerate() {
+                let ch = i % src_cn;
+                let idx = src.data[i] as usize;
+                *d = lut_data[idx * lut_cn + ch];
+            }
+        }
+    }
+
+    Ok(Matrix {
+        rows: src.rows,
+        cols: src.cols,
+        channels: src_cn,
+        data: dst_data,
+    })
 }
 
 #[cfg(test)]

--- a/src/core/dft.rs
+++ b/src/core/dft.rs
@@ -1,0 +1,490 @@
+/*
+ *  dft.rs
+ *  purecv
+ *
+ *  This file is part of purecv - OpenCV.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+use rustfft::num_complex::Complex;
+use rustfft::FftPlanner;
+
+use crate::core::error::{PureCvError, Result};
+use crate::core::matrix::Matrix;
+
+// ---------------------------------------------------------------------------
+// DFT flag constants (matching OpenCV values)
+// ---------------------------------------------------------------------------
+
+/// Compute the inverse DFT.
+pub const DFT_INVERSE: i32 = 1;
+/// Scale the result by `1 / (rows * cols)`.
+pub const DFT_SCALE: i32 = 2;
+/// Process each row independently (1-D transform per row).
+pub const DFT_ROWS: i32 = 4;
+/// Force complex (2-channel) output even for real input.
+pub const DFT_COMPLEX_OUTPUT: i32 = 16;
+/// Return only the real part of the result (1-channel output).
+pub const DFT_REAL_OUTPUT: i32 = 32;
+
+// ---------------------------------------------------------------------------
+// Optimal DFT size lookup table
+// ---------------------------------------------------------------------------
+
+/// Pre-computed table of numbers of the form 2^a * 3^b * 5^c, sorted.
+/// These are the sizes for which FFT algorithms are most efficient.
+const OPTIMAL_DFT_SIZES: &[i32] = &[
+    1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 15, 16, 18, 20, 24, 25, 27, 30, 32, 36, 40, 45, 48, 50, 54, 60,
+    64, 72, 75, 80, 81, 90, 96, 100, 108, 120, 125, 128, 135, 144, 150, 160, 162, 180, 192, 200,
+    216, 225, 240, 243, 250, 256, 270, 288, 300, 320, 324, 360, 375, 384, 400, 405, 432, 450, 480,
+    486, 500, 512, 540, 576, 600, 625, 640, 648, 675, 720, 729, 750, 768, 800, 810, 864, 900, 960,
+    972, 1000, 1024, 1080, 1125, 1152, 1200, 1215, 1250, 1280, 1296, 1350, 1440, 1458, 1500, 1536,
+    1600, 1620, 1728, 1800, 1875, 1920, 1944, 2000, 2025, 2048, 2160, 2187, 2250, 2304, 2400, 2430,
+    2500, 2560, 2592, 2700, 2880, 2916, 3000, 3072, 3125, 3200, 3240, 3375, 3456, 3600, 3645, 3750,
+    3840, 3888, 4000, 4050, 4096, 4320, 4374, 4500, 4608, 4800, 4860, 5000, 5120, 5184, 5400, 5625,
+    5760, 5832, 6000, 6075, 6144, 6250, 6400, 6480, 6561, 6750, 6912, 7200, 7290, 7500, 7680, 7776,
+    8000, 8100, 8192, 8640, 8748, 9000, 9216, 9375, 9600, 9720, 10000, 10125, 10240, 10368, 10800,
+    11250, 11520, 11664, 12000, 12150, 12288, 12500, 12800, 12960, 13122, 13500, 13824, 14400,
+    14580, 15000, 15360, 15552, 15625, 16000, 16200, 16384, 16875, 17280, 17496, 18000, 18225,
+    18432, 18750, 19200, 19440, 19683, 20000, 20250, 20480, 20736, 21600, 21870, 22500, 23040,
+    23328, 24000, 24300, 24576, 25000, 25600, 25920, 26244, 27000, 27648, 28125, 28800, 29160,
+    30000, 30375, 30720, 31104, 31250, 32000, 32400, 32768, 33750, 34560, 34992, 36000, 36450,
+    36864, 37500, 38400, 38880, 39366, 40000, 40500, 40960, 41472, 43200, 43740, 45000, 46080,
+    46656, 46875, 48000, 48600, 49152, 50000, 50625, 51200, 51840, 52488, 54000, 54675, 55296,
+    56250, 57600, 58320, 59049, 60000, 60750, 61440, 62208, 62500, 64000, 64800, 65536,
+];
+
+/// Returns the optimal DFT size greater than or equal to a given value.
+///
+/// Optimal sizes are of the form `2^a * 3^b * 5^c` which allow the FFT
+/// algorithm to run most efficiently.
+///
+/// Returns the input itself if `size <= 1`. Returns `-1` if `size` exceeds the
+/// largest pre-computed entry.
+pub fn get_optimal_dft_size(size: i32) -> i32 {
+    if size <= 1 {
+        return size.max(0);
+    }
+    match OPTIMAL_DFT_SIZES.iter().position(|&s| s >= size) {
+        Some(idx) => OPTIMAL_DFT_SIZES[idx],
+        None => {
+            // Fall back to computing: find smallest 2^a * 3^b * 5^c >= size
+            compute_optimal_size(size)
+        }
+    }
+}
+
+/// Compute the smallest number >= `size` that is a product of 2, 3, and 5.
+fn compute_optimal_size(size: i32) -> i32 {
+    let mut best = i32::MAX;
+    let mut p5 = 1i64;
+    while p5 < size as i64 * 2 {
+        let mut p35 = p5;
+        while p35 < size as i64 * 2 {
+            // Find smallest power of 2 such that p2 * p35 >= size
+            let mut p = p35;
+            while p < size as i64 {
+                p *= 2;
+            }
+            if p < best as i64 {
+                best = p as i32;
+            }
+            p35 *= 3;
+        }
+        p5 *= 5;
+    }
+    best
+}
+
+// ---------------------------------------------------------------------------
+// DftFloat trait (sealed)
+// ---------------------------------------------------------------------------
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for f32 {}
+    impl Sealed for f64 {}
+}
+
+/// Trait for floating-point types that support DFT operations.
+///
+/// This trait is sealed and only implemented for `f32` and `f64`.
+pub trait DftFloat:
+    sealed::Sealed + rustfft::FftNum + Default + Copy + Send + Sync + 'static
+{
+}
+
+impl DftFloat for f32 {}
+impl DftFloat for f64 {}
+
+// ---------------------------------------------------------------------------
+// DFT implementation
+// ---------------------------------------------------------------------------
+
+/// Performs a 2-D Discrete Fourier Transform.
+///
+/// The input matrix must be 1-channel (real) or 2-channel (complex, where
+/// channel 0 is real and channel 1 is imaginary).
+///
+/// # Arguments
+/// * `src` - Input matrix of type `f32` or `f64`.
+/// * `flags` - Combination of `DFT_*` constants (e.g. `DFT_INVERSE | DFT_SCALE`).
+/// * `nonzero_rows` - When non-zero, only the first `nonzero_rows` rows of the
+///   input are non-zero. This can speed up the transform. Pass `0` to process
+///   all rows.
+///
+/// # Returns
+/// A matrix containing the DFT result. Output is 2-channel (complex) unless
+/// `DFT_REAL_OUTPUT` is specified.
+pub fn dft<T: DftFloat>(src: &Matrix<T>, flags: i32, nonzero_rows: usize) -> Result<Matrix<T>> {
+    let inverse = (flags & DFT_INVERSE) != 0;
+    let scale = (flags & DFT_SCALE) != 0;
+    let rows_only = (flags & DFT_ROWS) != 0;
+    let want_complex_output = (flags & DFT_COMPLEX_OUTPUT) != 0;
+    let want_real_output = (flags & DFT_REAL_OUTPUT) != 0;
+
+    if src.channels != 1 && src.channels != 2 {
+        return Err(PureCvError::InvalidInput(
+            "dft requires 1-channel (real) or 2-channel (complex) input".into(),
+        ));
+    }
+
+    if want_real_output && want_complex_output {
+        return Err(PureCvError::InvalidInput(
+            "DFT_REAL_OUTPUT and DFT_COMPLEX_OUTPUT are mutually exclusive".into(),
+        ));
+    }
+
+    let is_complex_input = src.channels == 2;
+    let rows = src.rows;
+    let cols = src.cols;
+
+    if rows == 0 || cols == 0 {
+        return Err(PureCvError::InvalidDimensions(
+            "dft input must not be empty".into(),
+        ));
+    }
+
+    let active_rows = if nonzero_rows > 0 && nonzero_rows < rows {
+        nonzero_rows
+    } else {
+        rows
+    };
+
+    // Build the complex buffer from source
+    let mut buf = vec![Complex::<T>::default(); rows * cols];
+    let cn = src.channels;
+
+    for r in 0..rows {
+        for c in 0..cols {
+            if is_complex_input {
+                let base = (r * cols + c) * cn;
+                let re = src.data[base];
+                let im = src.data[base + 1];
+                buf[r * cols + c] = Complex::new(re, im);
+            } else if r < active_rows {
+                let re = src.data[r * cols + c];
+                buf[r * cols + c] = Complex::new(re, T::default());
+            }
+            // Rows beyond active_rows are already zero-initialized
+        }
+    }
+
+    let mut planner = FftPlanner::<T>::new();
+
+    // Row-wise FFTs
+    let row_fft = if inverse {
+        planner.plan_fft_inverse(cols)
+    } else {
+        planner.plan_fft_forward(cols)
+    };
+
+    for r in 0..rows {
+        let row_slice = &mut buf[r * cols..(r + 1) * cols];
+        row_fft.process(row_slice);
+    }
+
+    // Column-wise FFTs (unless DFT_ROWS)
+    if !rows_only && rows > 1 {
+        let col_fft = if inverse {
+            planner.plan_fft_inverse(rows)
+        } else {
+            planner.plan_fft_forward(rows)
+        };
+
+        let mut col_buf = vec![Complex::<T>::default(); rows];
+        for c in 0..cols {
+            // Extract column
+            for r in 0..rows {
+                col_buf[r] = buf[r * cols + c];
+            }
+            col_fft.process(&mut col_buf);
+            // Write back
+            for r in 0..rows {
+                buf[r * cols + c] = col_buf[r];
+            }
+        }
+    }
+
+    // Scale if requested
+    if scale {
+        let n = if rows_only {
+            T::from_usize(cols).unwrap_or_default()
+        } else {
+            T::from_usize(rows * cols).unwrap_or_default()
+        };
+        if n != T::default() {
+            let inv_n = T::from_f64(1.0).unwrap_or_default() / n;
+            for v in &mut buf {
+                v.re = v.re * inv_n;
+                v.im = v.im * inv_n;
+            }
+        }
+    }
+
+    // Build output matrix
+    if want_real_output {
+        let mut dst_data = vec![T::default(); rows * cols];
+        for (i, v) in buf.iter().enumerate() {
+            dst_data[i] = v.re;
+        }
+        return Ok(Matrix {
+            rows,
+            cols,
+            channels: 1,
+            data: dst_data,
+        });
+    }
+
+    // 2-channel complex output (default)
+    let mut dst_data = vec![T::default(); rows * cols * 2];
+    for (i, v) in buf.iter().enumerate() {
+        dst_data[i * 2] = v.re;
+        dst_data[i * 2 + 1] = v.im;
+    }
+    Ok(Matrix {
+        rows,
+        cols,
+        channels: 2,
+        data: dst_data,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_optimal_dft_size_exact() {
+        assert_eq!(get_optimal_dft_size(1), 1);
+        assert_eq!(get_optimal_dft_size(2), 2);
+        assert_eq!(get_optimal_dft_size(8), 8);
+        assert_eq!(get_optimal_dft_size(256), 256);
+    }
+
+    #[test]
+    fn test_get_optimal_dft_size_round_up() {
+        assert_eq!(get_optimal_dft_size(7), 8);
+        assert_eq!(get_optimal_dft_size(13), 15);
+        assert_eq!(get_optimal_dft_size(17), 18);
+        assert_eq!(get_optimal_dft_size(97), 100);
+    }
+
+    #[test]
+    fn test_get_optimal_dft_size_zero_negative() {
+        assert_eq!(get_optimal_dft_size(0), 0);
+        assert_eq!(get_optimal_dft_size(-5), 0);
+    }
+
+    #[test]
+    fn test_get_optimal_dft_size_large() {
+        // Should compute beyond table
+        let s = get_optimal_dft_size(70000);
+        assert!(s >= 70000);
+        // Verify it's a product of 2, 3, 5
+        let mut n = s;
+        while n % 2 == 0 {
+            n /= 2;
+        }
+        while n % 3 == 0 {
+            n /= 3;
+        }
+        while n % 5 == 0 {
+            n /= 5;
+        }
+        assert_eq!(n, 1, "Optimal size {} is not a product of 2,3,5", s);
+    }
+
+    #[test]
+    fn test_dft_inverse_roundtrip_f32() {
+        // Create a small real matrix
+        let src = Matrix::from_vec(2, 4, 1, vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+
+        // Forward DFT
+        let freq = dft(&src, DFT_COMPLEX_OUTPUT, 0).unwrap();
+        assert_eq!(freq.channels, 2);
+
+        // Inverse DFT with scale
+        let back = dft(&freq, DFT_INVERSE | DFT_SCALE | DFT_REAL_OUTPUT, 0).unwrap();
+        assert_eq!(back.channels, 1);
+        assert_eq!(back.rows, 2);
+        assert_eq!(back.cols, 4);
+
+        // Should recover original values within tolerance
+        for i in 0..src.data.len() {
+            assert!(
+                (back.data[i] - src.data[i]).abs() < 1e-4,
+                "Mismatch at index {}: got {} expected {}",
+                i,
+                back.data[i],
+                src.data[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_dft_inverse_roundtrip_f64() {
+        let src = Matrix::from_vec(4, 4, 1, (1..=16).map(|x| x as f64).collect());
+
+        let freq = dft(&src, DFT_COMPLEX_OUTPUT, 0).unwrap();
+        let back = dft(&freq, DFT_INVERSE | DFT_SCALE | DFT_REAL_OUTPUT, 0).unwrap();
+
+        for i in 0..src.data.len() {
+            assert!(
+                (back.data[i] - src.data[i]).abs() < 1e-10,
+                "Mismatch at index {}: got {} expected {}",
+                i,
+                back.data[i],
+                src.data[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_dft_dc_component() {
+        // DFT of constant signal: DC = N * value, all others = 0
+        let val = 3.0f64;
+        let n = 4;
+        let src = Matrix::from_vec(1, n, 1, vec![val; n]);
+
+        let freq = dft(&src, DFT_COMPLEX_OUTPUT, 0).unwrap();
+        // DC component (0,0) real part should be n * val
+        // freq is 2-channel: data layout is [re0, im0, re1, im1, ...]
+        let dc_re = freq.data[0]; // re of (0,0)
+        assert!(
+            (dc_re - (n as f64 * val)).abs() < 1e-10,
+            "DC component: got {} expected {}",
+            dc_re,
+            n as f64 * val
+        );
+        // All other components should be zero
+        for c in 1..n {
+            let re = freq.data[c * 2];
+            let im = freq.data[c * 2 + 1];
+            assert!(re.abs() < 1e-10, "Non-zero real at col {}: {}", c, re);
+            assert!(im.abs() < 1e-10, "Non-zero imag at col {}: {}", c, im);
+        }
+    }
+
+    #[test]
+    fn test_dft_rows_flag() {
+        // With DFT_ROWS, each row is transformed independently
+        let src = Matrix::from_vec(2, 4, 1, vec![1.0f64, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]);
+
+        let freq_rows = dft(&src, DFT_ROWS | DFT_COMPLEX_OUTPUT, 0).unwrap();
+        let freq_2d = dft(&src, DFT_COMPLEX_OUTPUT, 0).unwrap();
+
+        // Row-wise result should differ from full 2D result
+        let mut any_diff = false;
+        for i in 0..freq_rows.data.len() {
+            if (freq_rows.data[i] - freq_2d.data[i]).abs() > 1e-10 {
+                any_diff = true;
+                break;
+            }
+        }
+        assert!(
+            any_diff,
+            "DFT_ROWS should produce different result than 2D DFT"
+        );
+    }
+
+    #[test]
+    fn test_dft_scale_flag() {
+        let src = Matrix::from_vec(2, 2, 1, vec![1.0f64, 2.0, 3.0, 4.0]);
+
+        let unscaled = dft(&src, DFT_COMPLEX_OUTPUT, 0).unwrap();
+        let scaled = dft(&src, DFT_COMPLEX_OUTPUT | DFT_SCALE, 0).unwrap();
+
+        let n = (src.rows * src.cols) as f64;
+        for i in 0..unscaled.data.len() {
+            assert!(
+                (scaled.data[i] - unscaled.data[i] / n).abs() < 1e-10,
+                "Scale mismatch at index {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_dft_multichannel_error() {
+        let src = Matrix::from_vec(2, 2, 3, vec![0.0f32; 12]);
+        assert!(dft(&src, 0, 0).is_err());
+    }
+
+    #[test]
+    fn test_dft_empty_error() {
+        let src = Matrix::<f32>::new(0, 0, 1);
+        assert!(dft(&src, 0, 0).is_err());
+    }
+
+    #[test]
+    fn test_dft_complex_input() {
+        // 2-channel (complex) input
+        let src = Matrix::from_vec(1, 4, 2, vec![1.0f64, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, -1.0]);
+
+        let freq = dft(&src, 0, 0).unwrap();
+        assert_eq!(freq.channels, 2);
+
+        // Inverse should recover original
+        let back = dft(&freq, DFT_INVERSE | DFT_SCALE, 0).unwrap();
+        for i in 0..src.data.len() {
+            assert!(
+                (back.data[i] - src.data[i]).abs() < 1e-10,
+                "Complex roundtrip mismatch at {}",
+                i
+            );
+        }
+    }
+}

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1141,7 +1141,77 @@ mod tests {
     #[test]
     fn test_count_non_zero() {
         let m = Matrix::from_vec(1, 6, 1, vec![0i32, 1, 0, 3, 0, 5]);
-        assert_eq!(count_non_zero(&m), 3);
+        assert_eq!(count_non_zero(&m).unwrap(), 3);
+
+        // All zeros
+        let m_zeros = Matrix::from_vec(1, 4, 1, vec![0i32, 0, 0, 0]);
+        assert_eq!(count_non_zero(&m_zeros).unwrap(), 0);
+
+        // All non-zero
+        let m_all = Matrix::from_vec(1, 3, 1, vec![1i32, 2, 3]);
+        assert_eq!(count_non_zero(&m_all).unwrap(), 3);
+
+        // Multi-channel should error
+        let m_multi = Matrix::from_vec(1, 3, 2, vec![0i32, 1, 0, 3, 0, 5]);
+        assert!(count_non_zero(&m_multi).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // LUT (Look-Up Table)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_lut_identity() {
+        // Identity LUT: output should equal input
+        let src = Matrix::from_vec(1, 5, 1, vec![0u8, 50, 100, 200, 255]);
+        let table_data: Vec<u8> = (0..=255).collect();
+        let table = Matrix::from_vec(1, 256, 1, table_data);
+        let dst = lut(&src, &table).unwrap();
+        assert_eq!(dst.data, vec![0u8, 50, 100, 200, 255]);
+    }
+
+    #[test]
+    fn test_lut_invert() {
+        // Invert LUT: 255 - x
+        let src = Matrix::from_vec(1, 3, 1, vec![0u8, 127, 255]);
+        let table_data: Vec<u8> = (0..=255).rev().collect();
+        let table = Matrix::from_vec(1, 256, 1, table_data);
+        let dst = lut(&src, &table).unwrap();
+        assert_eq!(dst.data, vec![255u8, 128, 0]);
+    }
+
+    #[test]
+    fn test_lut_type_conversion() {
+        // u8 src -> f32 output via LUT
+        let src = Matrix::from_vec(1, 3, 1, vec![0u8, 1, 2]);
+        let table_data: Vec<f32> = (0..256).map(|x| x as f32 * 0.5).collect();
+        let table = Matrix::from_vec(1, 256, 1, table_data);
+        let dst = lut(&src, &table).unwrap();
+        assert_eq!(dst.data, vec![0.0f32, 0.5, 1.0]);
+    }
+
+    #[test]
+    fn test_lut_multichannel_broadcast() {
+        // 3-channel src with 1-channel LUT (broadcast)
+        let src = Matrix::from_vec(1, 2, 3, vec![0u8, 1, 2, 10, 20, 30]);
+        let table_data: Vec<u8> = (0..=255).map(|x: u8| x.wrapping_mul(2)).collect();
+        let table = Matrix::from_vec(1, 256, 1, table_data);
+        let dst = lut(&src, &table).unwrap();
+        assert_eq!(dst.data, vec![0u8, 2, 4, 20, 40, 60]);
+    }
+
+    #[test]
+    fn test_lut_wrong_size_error() {
+        let src = Matrix::from_vec(1, 3, 1, vec![0u8, 1, 2]);
+        let table = Matrix::from_vec(1, 128, 1, vec![0u8; 128]);
+        assert!(lut(&src, &table).is_err());
+    }
+
+    #[test]
+    fn test_lut_channel_mismatch_error() {
+        let src = Matrix::from_vec(1, 2, 3, vec![0u8; 6]);
+        let table = Matrix::from_vec(1, 256, 2, vec![0u8; 512]);
+        assert!(lut(&src, &table).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the remaining unchecked functions from issue #5:

- **`count_non_zero`** — Added single-channel validation (`channels == 1`), changed return type to `Result<i32>` to match OpenCV's assertion behavior
- **`lut`** — New look-up table transform: maps `Matrix<u8>` pixel values through a 256-entry table. Supports single-channel LUT broadcast and per-channel LUT. Parallel-enabled via rayon
- **`dft`** — 2D Discrete Fourier Transform using `rustfft` crate behind optional `fft` feature flag. Supports `f32`/`f64`, real and complex input/output, flags: `DFT_INVERSE`, `DFT_SCALE`, `DFT_ROWS`, `DFT_COMPLEX_OUTPUT`, `DFT_REAL_OUTPUT`
- **`get_optimal_dft_size`** — Returns smallest FFT-friendly size ≥ input (products of 2, 3, 5). Pre-computed lookup table with fallback computation
- **Benchmarks** — Criterion benchmarks for all new functions with measured timings in `benchmark_results.md`

### Files changed
| File | Change |
|------|--------|
| `src/core/arithm.rs` | Fix `count_non_zero` return type, add `lut` |
| `src/core/dft.rs` | **New** — `dft`, `get_optimal_dft_size`, DFT flags, `DftFloat` trait |
| `src/core.rs` | Wire up `dft` module (feature-gated), export `lut` |
| `src/core/tests.rs` | Updated + new tests (count_non_zero, lut) |
| `Cargo.toml` | Add `rustfft` optional dep, `fft` feature, `dft_bench` entry |
| `benches/arithm_bench.rs` | Add count_non_zero and lut benchmarks |
| `benches/dft_bench.rs` | **New** — DFT benchmarks (feature-gated) |
| `benches/benchmark_results.md` | Actual measured timings |

Closes #5

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` and `cargo clippy --features fft` pass with no warnings
- [x] `cargo test` passes (179 tests, default features)
- [x] `cargo test --features fft` passes (all DFT tests included)
- [x] `cargo bench --bench arithm_bench --no-run` compiles
- [x] `cargo bench --bench dft_bench --features fft --no-run` compiles
- [x] Benchmarks run and produce valid timings

🤖 Generated with [Claude Code](https://claude.com/claude-code)