### PR TITLE
feat(core): add data_ptr, data_ptr_mut, and copy_to to Matrix<T>

### DIFF
--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -547,6 +547,64 @@ impl<T: Default + Clone> Matrix<T> {
     pub fn swap(&mut self, other: &mut Self) {
         std::mem::swap(self, other);
     }
+
+    /// Returns a raw immutable pointer to the start of the underlying data
+    /// buffer, cast to `*const u8`.
+    ///
+    /// This is useful for zero-copy interop with WASM host buffers and
+    /// low-level SIMD intrinsics that need a stable byte address.
+    ///
+    /// # Safety (for callers)
+    /// Dereferencing the returned pointer requires `unsafe`. The pointer
+    /// is valid as long as `self` is alive and no reallocation occurs.
+    #[inline]
+    pub fn data_ptr(&self) -> *const u8 {
+        self.data.as_ptr() as *const u8
+    }
+
+    /// Returns a raw mutable pointer to the start of the underlying data
+    /// buffer, cast to `*mut u8`.
+    ///
+    /// # Safety (for callers)
+    /// Dereferencing the returned pointer requires `unsafe`. The pointer
+    /// is valid as long as `self` is alive and no reallocation occurs.
+    #[inline]
+    pub fn data_ptr_mut(&mut self) -> *mut u8 {
+        self.data.as_mut_ptr() as *mut u8
+    }
+
+    /// Deep-copies the contents of `self` into `dst`.
+    ///
+    /// After the call, `dst` is an independent copy of `self` with
+    /// identical dimensions, channel count, and data. If `dst` already
+    /// has the correct shape, only the data is overwritten (no allocation).
+    /// If the shape differs, `dst` is reallocated to match `self`.
+    ///
+    /// # Example
+    /// ```
+    /// use purecv::core::Matrix;
+    /// let src = Matrix::<u8>::from_vec(2, 2, 1, vec![1, 2, 3, 4]);
+    /// let mut dst = Matrix::<u8>::new(0, 0, 0);
+    /// src.copy_to(&mut dst).unwrap();
+    /// assert_eq!(src.data, dst.data);
+    /// assert_eq!(dst.rows, 2);
+    /// ```
+    pub fn copy_to(&self, dst: &mut Matrix<T>) -> Result<()> {
+        if self.rows != dst.rows || self.cols != dst.cols || self.channels != dst.channels {
+            #[cfg(debug_assertions)]
+            eprintln!(
+                "[purecv::copy_to] dst resized from {}x{}x{} to {}x{}x{}",
+                dst.rows, dst.cols, dst.channels, self.rows, self.cols, self.channels
+            );
+            dst.rows = self.rows;
+            dst.cols = self.cols;
+            dst.channels = self.channels;
+            dst.data = self.data.clone();
+        } else {
+            dst.data.clone_from(&self.data);
+        }
+        Ok(())
+    }
 }
 
 impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1521,4 +1521,61 @@ mod core_tests {
         assert!((CV_E - std::f64::consts::E).abs() < f64::EPSILON);
         assert!((CV_LN10 - std::f64::consts::LN_10).abs() < f64::EPSILON);
     }
+
+    // ---- data_ptr / data_ptr_mut / copy_to tests ----
+
+    #[test]
+    fn test_data_ptr() {
+        let mat = Matrix::<u8>::from_vec(2, 2, 1, vec![10, 20, 30, 40]);
+        let ptr = mat.data_ptr();
+        assert!(!ptr.is_null());
+        // The pointer should point to the first element
+        unsafe {
+            assert_eq!(*ptr, 10u8);
+        }
+    }
+
+    #[test]
+    fn test_data_ptr_mut() {
+        let mut mat = Matrix::<u8>::from_vec(1, 3, 1, vec![1, 2, 3]);
+        let ptr = mat.data_ptr_mut();
+        assert!(!ptr.is_null());
+        // Mutate through the pointer and verify via safe API
+        unsafe {
+            *ptr = 99;
+        }
+        assert_eq!(mat.get(0, 0, 0), Some(&99u8));
+    }
+
+    #[test]
+    fn test_copy_to_same_shape() {
+        let src = Matrix::<f32>::from_vec(2, 3, 1, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let mut dst = Matrix::<f32>::new(2, 3, 1);
+        src.copy_to(&mut dst).unwrap();
+        assert_eq!(src.data, dst.data);
+        assert_eq!(dst.rows, 2);
+        assert_eq!(dst.cols, 3);
+    }
+
+    #[test]
+    fn test_copy_to_resize() {
+        let src = Matrix::<u8>::from_vec(2, 2, 3, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        let mut dst = Matrix::<u8>::new(0, 0, 0); // empty dst
+        src.copy_to(&mut dst).unwrap();
+        assert_eq!(dst.rows, 2);
+        assert_eq!(dst.cols, 2);
+        assert_eq!(dst.channels, 3);
+        assert_eq!(src.data, dst.data);
+    }
+
+    #[test]
+    fn test_copy_to_independence() {
+        // Verify deep copy — modifying dst does not affect src
+        let src = Matrix::<i32>::from_vec(1, 3, 1, vec![10, 20, 30]);
+        let mut dst = Matrix::<i32>::new(0, 0, 0);
+        src.copy_to(&mut dst).unwrap();
+        dst.set(0, 0, 0, 999);
+        assert_eq!(src.get(0, 0, 0), Some(&10)); // src unchanged
+        assert_eq!(dst.get(0, 0, 0), Some(&999));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #43

Adds three utility methods to `Matrix<T>` that are standard in any OpenCV-compatible matrix API:

### New Methods

| Method | Signature | Purpose |
|--------|-----------|---------|
| `data_ptr` | `&self -> *const u8` | Raw immutable byte pointer for WASM/SIMD interop |
| `data_ptr_mut` | `&mut self -> *mut u8` | Raw mutable byte pointer |
| `copy_to` | `&self, dst: &mut Matrix<T> -> Result<()>` | Deep copy with auto-resize |

### Design Decisions

- **Byte pointers** (`*const u8`): Matches OpenCV's `Mat::data` (`uchar*`). Typed access already available via `as_slice().as_ptr()`.
- **Auto-resize on copy_to**: Follows OpenCV `Mat::copyTo` behavior. If `dst` has different dimensions, it is reallocated.
- **Debug warning**: `copy_to` emits `eprintln!` when resizing `dst`, gated behind `#[cfg(debug_assertions)]`.
- **No unsafe in method bodies**: Methods return raw pointers but contain no `unsafe` blocks. The `unsafe` burden is on the caller.
- **No new dependencies** introduced.

### Tests

5 unit tests added to `src/core/tests.rs`:
- `test_data_ptr` — non-null pointer, correct first byte
- `test_data_ptr_mut` — mutation through raw pointer
- `test_copy_to_same_shape` — copy to pre-allocated matching dst
- `test_copy_to_resize` — copy to empty dst with auto-resize
- `test_copy_to_independence` — deep copy independence verification

### Checklist

- [x] `Matrix<T>::data_ptr(&self) -> *const u8` added
- [x] `Matrix<T>::data_ptr_mut(&mut self) -> *mut u8` added
- [x] `Matrix<T>::copy_to(&self, dst: &mut Matrix<T>) -> Result<()>` added
- [x] Unit tests added in `src/core/tests.rs`
- [x] `cargo fmt` ✅
- [x] `cargo clippy` ✅
- [x] `cargo test` ✅ (all 209+ tests pass)