### PR TITLE
docs(wasm): fix outdated api references in readme (fixes #42)

### DIFF
--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -22,24 +22,20 @@ npm install @webarkit/purecv-wasm
 
 ```javascript
 // Example using a bundler (webpack, vite) or in Node.js
-import init, { PureCvMatrixU8, gaussianBlur } from '@webarkit/purecv-wasm/dist-std/purecv.js';
+import init, { Mat, gaussian_blur, CV_8UC3, BORDER_DEFAULT } from '@webarkit/purecv-wasm/dist-std/purecv_wasm.js';
 
 async function run() {
     // Initialize WebAssembly
     await init();
 
-    const width = 640;
-    const height = 480;
-    const channels = 3;
-
-    // Create a new matrix
-    const mat = PureCvMatrixU8.create(width, height, channels);
+    // Mat.new(rows, cols, mat_type)
+    const mat = Mat.new(480, 640, CV_8UC3);
     
     // Process your image data here...
     // For example, uploading an ImageData array buffer to `mat`
 
-    // Apply a Gaussian Blur of size 5x5
-    const blurredMat = gaussianBlur(mat, 5, 5, 0.0, 0.0);
+    // gaussian_blur(src, ksize_w, ksize_h, sigma_x, sigma_y, border_type)
+    const blurredMat = gaussian_blur(mat, 5, 5, 0.0, 0.0, BORDER_DEFAULT);
 
     // Free memory manually!
     mat.free();
@@ -53,13 +49,13 @@ For a concrete, runnable example directly in an HTML file using `fetch`, check o
 
 ## Memory Management
 
-Because WebAssembly runs linearly in memory and holds pointers to Rust `Vec` objects, memory allocated for matrices such as `PureCvMatrixU8` and `PureCvMatrix` are not automatically garbage collected by JavaScript. When you are done manipulating your matrix, **you must ensure you call `.free()`** to prevent memory leaks in the browser.
+Because WebAssembly runs linearly in memory and holds pointers to Rust `Vec` objects, memory allocated for matrices such as `Mat` are not automatically garbage collected by JavaScript. When you are done manipulating your matrix, **you must ensure you call `.free()`** to prevent memory leaks in the browser.
 
 ## API coverage
 
 Right now we have covered a large majority of operations for `core` and `imgproc`:
 
-- **Core**: Arithmetic (`add`, `subtract`, `multiply`, `absDiff` etc.), Structural (`hconcat`, `vconcat`, `flip`), Geometry, constants etc.
-- **ImgProc**: Filters (`blur`, `gaussianBlur`, `bilateralFilter`), Thresholding (`threshold`), Coloring (`cvtColor`), Edge Derivatives (`canny`, `sobel`, `laplacian`), Morphology (`erode`, `dilate`, `morphologyEx`, `getStructuringElement`), Pyramids (`pyrDown`, `pyrUp`, `buildPyramid`).
+- **Core**: Arithmetic (`add`, `subtract`, `multiply`, `absdiff` etc.), Structural (`hconcat`, `vconcat`, `flip`), Geometry, constants etc.
+- **ImgProc**: Filters (`blur`, `gaussian_blur`, `bilateral_filter`), Thresholding (`threshold`), Coloring (`cvt_color`), Edge Derivatives (`canny`, `sobel`, `laplacian`), Morphology (`erode`, `dilate`, `morphology_ex`, `get_structuring_element`), Pyramids (`pyr_down`, `pyr_up`, `build_pyramid`).
 
 Note: To interface between JavaScript Typed Arrays and `purecv-wasm`, please use the available getter functions (`.data()`) which directly retrieve a Float32Array or Uint8Array view into WASM memory.


### PR DESCRIPTION
## PR Summary
- **Type**: Documentation fix
- **Files changed**: `crates/wasm/README.md`
- **Impact**: Resolves user confusion about the WASM API.

## Detailed Description
This PR addresses #42, where the npm README for `@webarkit/purecv-wasm` contained outdated API references that caused runtime errors for users. 

The following corrections were made to the documentation:
1. Replaced `PureCvMatrixU8` with the actual exported `Mat` class.
2. Updated `Mat.create()` to the correct `Mat.new()` syntax.
3. Changed camelCase function names (e.g., `gaussianBlur`) to the modern snake_case WASM bindings (`gaussian_blur`).
4. Replaced hardcoded integer values with proper imports (`CV_8UC3` and `BORDER_DEFAULT`).
5. Updated the API coverage section to reflect the snake_case naming conventions (e.g., `absdiff`, `cvt_color`, `morphology_ex`).
6. Fixed the import path (`dist-std/purecv_wasm.js`).

## Review Checklist
- [x] Code examples are copy-pasteable and syntactically correct.
- [x] Referenced constants (`CV_8UC3`, `BORDER_DEFAULT`) are properly imported.
- [x] Memory management section accurately references `Mat` instead of `PureCvMatrixU8`.
- [x] API coverage list uses up-to-date snake_case names.

## Risk Assessment
- **Risk Level**: Lowest
- **Mitigation**: This is solely a documentation change targeting the WASM package README. It does not affect the actual `purecv` Rust or WASM code execution.

## Test Coverage
- **N/A** (Documentation only)

## Size Recommendations
- **Status**: Excellent. This PR is small, atomic, and addresses a single issue directly.

Fixes #42