### PR TITLE
feat(core): no_std support for the core module (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,34 @@ jobs:
     - name: Run tests (with ndarray feature)
       run: cargo test --workspace --features ndarray
 
+  no-std-build:
+    name: no_std Build (core only, issue #83)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+        targets: thumbv7em-none-eabihf
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Build without default features (host)
+      run: cargo build --no-default-features
+
+    - name: Lint without default features
+      run: cargo clippy --no-default-features -- -D warnings
+
+    - name: Build for bare-metal target
+      run: cargo build --no-default-features --target thumbv7em-none-eabihf
+
+    - name: Build no_std smoke-test consumer
+      run: cargo build --manifest-path crates/no-std-smoke/Cargo.toml --target thumbv7em-none-eabihf
+
   wasm-build:
     name: WASM Dual Build
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "purecv"
 version = "0.6.1"
 authors = ["Walter Perdan <https://github.com/kalwalt>"]
 edition = "2021"
+rust-version = "1.88"
 description = "A pure Rust, high-performance computer vision library focused on safety and portability."
 license = "LGPL-2.1-or-later"
 repository = "https://github.com/webarkit/purecv"
@@ -16,11 +17,11 @@ path = "src/lib.rs"
 [dependencies]
 rayon = { version = "1.10", optional = true }
 ndarray = { version = "0.17", optional = true }
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 pulp = { version = "0.22", optional = true }
 rustfft = { version = "6", optional = true }
 num-complex = { version = "0.4", optional = true }
-log = "0.4"
+log = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 image = "0.25"
@@ -28,11 +29,12 @@ criterion = "0.8"
 
 [features]
 default = ["std", "parallel"]
-std = []
-parallel = ["rayon"]
-ndarray = ["dep:ndarray"]
-simd = ["dep:pulp"]
-fft = ["dep:rustfft", "dep:num-complex"]
+std = ["num-traits/std"]
+# The features below require `std` until their own no_std phases land (see issue #82).
+parallel = ["dep:rayon", "std"]
+ndarray = ["dep:ndarray", "std"]
+simd = ["dep:pulp", "std"]
+fft = ["dep:rustfft", "dep:num-complex", "std"]
 transforms = ["fft"]
 
 [[bench]]
@@ -79,6 +81,9 @@ panic = "abort"
 
 [workspace]
 members = ["crates/wasm"]
+# Built separately against bare-metal targets (see the no-std CI job); keeping it
+# out of the workspace lets `cargo build --workspace` stay host-only.
+exclude = ["crates/no-std-smoke"]
 
 [workspace.package]
 version = "0.6.1"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Unlike existing wrappers, **PureCV** is a native rewrite. It aims to provide:
 - **Random Number Generation:** `randu` (uniform distribution), `randn` (normal/Gaussian distribution), `set_rng_seed`.
 - **Channel Management:** `split`, `merge`, `mix_channels`.
 - **Utilities:** `add_weighted`, `check_range`, `absdiff`, `get_tick_count`, `get_tick_frequency`.
+- **Logging** (OpenCV-style): a `cv::utils::logging`-compatible facade over the [`log`](https://crates.io/crates/log) crate — a 7-level `LogLevel` with `set_log_level`/`get_log_level`, per-subsystem `tags`, `cv_log_*!` macros, and `cv_bail!`/`cv_err!` log-and-return helpers used throughout `core` to report invalid input (wrong dimensions, channel mismatches, …). Bring your own backend (`env_logger`, `tracing`, …) or call `init_basic_logger()` for quick stdout output.
 - **Mathematical Constants:** OpenCV-compatible constants — `CV_PI`, `CV_PI_2`, `CV_2PI`, `CV_PI_4`, `CV_LOG2`, `CV_LN2`, `CV_E`, `CV_LN10`, `CV_SQRT2` — backed by `std::f64::consts` for maximum precision.
 - **ndarray Interop:** Optional, zero-cost conversions to/from `ndarray::Array3` via the `ndarray` feature flag.
 - **SIMD Acceleration** (`simd` feature): Trait-based dispatch via `pulp` for `f32`, `f64`, and `u8` types. Accelerated operations include `add`, `sub`, `mul`, `div`, `min`, `max`, `sqrt`, `dot`, `sum`, `add_weighted`, `convert_scale_abs`, `magnitude`, `simd_row_min_max`, `simd_min_max_col`, `simd_gaussian_5tap_h/v`, and `simd_remap_bilinear_row`/`simd_remap_nearest_row`. Falls back to scalar loops at zero cost when disabled.
@@ -160,6 +161,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Matrix size: {}x{}", mat.cols, mat.rows);
     Ok(())
 }
+```
+
+### Logging
+
+PureCV mirrors OpenCV's `cv::utils::logging` on top of the [`log`](https://crates.io/crates/log)
+facade, so the output backend stays your choice (`env_logger`, `tracing`,
+`console_log` on WASM, …). For a quick start, `init_basic_logger()` installs a
+simple stdout logger. Internally, `core` logs a warning whenever a function
+rejects invalid input:
+
+```rust
+use purecv::core::arithm;
+use purecv::core::logging::{self, LogLevel};
+use purecv::core::Matrix;
+
+fn main() {
+    // Install the built-in stdout logger and let warnings through.
+    logging::init_basic_logger().ok();
+    logging::set_log_level(LogLevel::Warning);
+
+    // Mismatched dimensions -> logs a warning AND returns Err(..)
+    let a = Matrix::<f32>::new(4, 4, 3);
+    let b = Matrix::<f32>::new(2, 2, 1);
+    let _ = arithm::add(&a, &b);
+    // [WARN] purecv::core - add: matrices must have the same dimensions (src1 4×4×3, src2 2×2×1)
+}
+```
+
+You can also emit your own messages with the `cv_log_*!` macros and filter per
+subsystem via the standard `RUST_LOG` syntax (e.g. `RUST_LOG=purecv::core=warn`):
+
+```rust
+use purecv::core::logging::tags;
+purecv::cv_log_info!(tags::IMGPROC, "gaussian blur, ksize = {}", 5);
 ```
 
 ### ndarray Interoperability

--- a/crates/no-std-smoke/Cargo.toml
+++ b/crates/no-std-smoke/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "purecv-no-std-smoke"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Build-only smoke test: consumes the purecv public API from a no_std crate (see issue #83)."
+
+[dependencies]
+purecv = { path = "../..", default-features = false }
+
+# Standalone workspace root: keeps this build-only crate out of both the
+# purecv workspace and any enclosing one.
+[workspace]

--- a/crates/no-std-smoke/src/lib.rs
+++ b/crates/no-std-smoke/src/lib.rs
@@ -1,0 +1,65 @@
+/*
+ *  lib.rs
+ *  purecv
+ *
+ *  This file is part of purecv - WebARKit.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Build-only `no_std` smoke test for `purecv` (issue #83).
+//!
+//! This crate never runs; compiling it for a bare-metal target such as
+//! `thumbv7em-none-eabihf` proves that the `purecv` core API is usable
+//! from a `no_std` + `alloc` consumer:
+//!
+//! ```sh
+//! cargo build --target thumbv7em-none-eabihf
+//! ```
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec;
+use purecv::core::error::Result;
+use purecv::core::{add, determinant, mean, Matrix};
+
+/// Exercises matrix construction, arithmetic, statistics, and linear algebra.
+pub fn smoke() -> Result<f64> {
+    let a = Matrix::<f32>::from_vec(2, 2, 1, vec![1.0, 2.0, 3.0, 4.0]);
+    let b = Matrix::<f32>::from_vec(2, 2, 1, vec![5.0, 6.0, 7.0, 8.0]);
+
+    let sum = add(&a, &b)?;
+    let avg = mean(&sum);
+    let det = determinant(&sum);
+
+    Ok(avg.v[0] + det)
+}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -22,7 +22,9 @@ web-sys = { version = "0.3.69", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 num-traits = "0.2"
-purecv = { path = "../../", default-features = false }
+# default-features = false keeps rayon (parallel) out of the wasm build;
+# `std` must be re-enabled explicitly now that it gates the non-core modules.
+purecv = { path = "../../", default-features = false, features = ["std"] }
 
 [features]
 default = []

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -35,28 +35,42 @@
  */
 
 use image::{DynamicImage, GenericImageView, ImageBuffer, Luma, Rgb};
+use purecv::core::logging::tags;
 use purecv::core::{normalize, BorderTypes, Matrix, NormTypes, Size};
 use purecv::imgproc::{
     bilateral_filter, blur, canny, cvt_color_rgb_to_gray, gaussian_blur, laplacian, median_blur,
     scharr, sobel,
 };
 use purecv::version;
+use purecv::{cv_log_error, cv_log_info};
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("--- purecv Filters Example ---");
-    println!("purecv v{}", version::get_version());
+    purecv::core::logging::init_basic_logger()?;
+
+    cv_log_info!(tags::PURECV, "--- Filters Example ---");
+    version::print_version();
 
     // 1. Load the image
     let img_path = "examples/data/butterfly.jpg";
     if !Path::new(img_path).exists() {
-        eprintln!("Error: {} not found. Run from the project root.", img_path);
+        cv_log_error!(
+            tags::IMGPROC,
+            "{} not found. Run from the project root.",
+            img_path
+        );
         return Ok(());
     }
 
     let img = image::open(img_path)?;
     let (width, height) = img.dimensions();
-    println!("Loaded image: {} ({}x{})", img_path, width, height);
+    cv_log_info!(
+        tags::IMGPROC,
+        "loaded image: {} ({}x{})",
+        img_path,
+        width,
+        height
+    );
 
     // 2. Convert to purecv Matrix<u8> (RGB)
     let rgb_img = img.to_rgb8();
@@ -68,7 +82,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- Apply Filters ---
 
     // Blur (Box Filter)
-    println!("Applying Blur...");
+    cv_log_info!(tags::IMGPROC, "applying blur...");
     let blurred = blur(
         &mat_rgb,
         Size::new(5, 5),
@@ -78,22 +92,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     save_matrix_rgb(&blurred, "examples/data/out/output_blur.png")?;
 
     // Gaussian Blur
-    println!("Applying Gaussian Blur...");
+    cv_log_info!(tags::IMGPROC, "applying gaussian blur...");
     let g_blurred = gaussian_blur(&mat_rgb, Size::new(5, 5), 1.5, 1.5, BorderTypes::Reflect101)?;
     save_matrix_rgb(&g_blurred, "examples/data/out/output_gaussian_blur.png")?;
 
     // Median Blur
-    println!("Applying Median Blur...");
+    cv_log_info!(tags::IMGPROC, "applying median blur...");
     let m_blurred = median_blur(&mat_rgb, 5)?;
     save_matrix_rgb(&m_blurred, "examples/data/out/output_median_blur.png")?;
 
     // Bilateral Filter
-    println!("Applying Bilateral Filter...");
+    cv_log_info!(tags::IMGPROC, "applying bilateral filter...");
     let b_filtered = bilateral_filter(&mat_rgb, 9, 75.0, 75.0, BorderTypes::Reflect101)?;
     save_matrix_rgb(&b_filtered, "examples/data/out/output_bilateral.png")?;
 
     // Sobel (on grayscale)
-    println!("Applying Sobel...");
+    cv_log_info!(tags::IMGPROC, "applying sobel...");
     let sob_x = sobel(&mat_gray, 1, 0, 3, 1.0, 0.0, BorderTypes::Reflect101)?;
     // Normalize for visualization
     let mut sob_x_norm = Matrix::<u8>::new(sob_x.rows, sob_x.cols, sob_x.channels);
@@ -109,7 +123,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     save_matrix_gray(&sob_x_norm, "examples/data/out/output_sobel_x.png")?;
 
     // Scharr (on grayscale)
-    println!("Applying Scharr...");
+    cv_log_info!(tags::IMGPROC, "applying scharr...");
     let sch_y = scharr(&mat_gray, 0, 1, 1.0, 0.0, BorderTypes::Reflect101)?;
     let mut sch_y_norm = Matrix::<u8>::new(sch_y.rows, sch_y.cols, sch_y.channels);
     normalize(
@@ -124,18 +138,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     save_matrix_gray(&sch_y_norm, "examples/data/out/output_scharr_y.png")?;
 
     // Laplacian (on grayscale)
-    println!("Applying Laplacian...");
+    cv_log_info!(tags::IMGPROC, "applying laplacian...");
     let lap = laplacian(&mat_gray, 3, 1.0, 0.0, BorderTypes::Reflect101)?;
     let mut lap_norm = Matrix::<u8>::new(lap.rows, lap.cols, lap.channels);
     normalize(&lap, &mut lap_norm, 0.0, 255.0, NormTypes::MinMax, -1, None)?;
     save_matrix_gray(&lap_norm, "examples/data/out/output_laplacian.png")?;
 
     // Canny (on grayscale)
-    println!("Applying Canny...");
+    cv_log_info!(tags::IMGPROC, "applying canny...");
     let edges = canny(&mat_gray, 50.0, 150.0, 3, false)?;
     save_matrix_gray(&edges, "examples/data/out/output_canny.png")?;
 
-    println!("\nAll filters applied successfully! Check the output_*.png files.");
+    cv_log_info!(
+        tags::IMGPROC,
+        "all filters applied successfully! Check the output_*.png files."
+    );
     Ok(())
 }
 

--- a/examples/match_features.rs
+++ b/examples/match_features.rs
@@ -52,21 +52,26 @@
 //! ```
 
 use image::{DynamicImage, GenericImageView, ImageBuffer, Rgb};
+use purecv::core::logging::tags;
 use purecv::core::Matrix;
 use purecv::features2d::{draw_matches, BFMatcher, DescriptorMatcher, NormType, Orb, ScoreType};
 use purecv::imgproc::cvt_color_rgb_to_gray;
 use purecv::version;
+use purecv::{cv_log_debug, cv_log_error, cv_log_info};
 use std::path::Path;
 use std::time::Instant;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("--- purecv Feature Matching Example ---");
-    println!("purecv version: v{}", version::get_version());
+    purecv::core::logging::init_basic_logger()?;
+
+    cv_log_info!(tags::PURECV, "--- Feature Matching Example ---");
+    version::print_version();
 
     let img_path = "examples/data/graf.png";
     if !Path::new(img_path).exists() {
-        eprintln!(
-            "Error: {} not found. Make sure you are in the project root.",
+        cv_log_error!(
+            tags::FEATURES2D,
+            "{} not found. Make sure you are in the project root.",
             img_path
         );
         return Ok(());
@@ -79,8 +84,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let load_start = Instant::now();
     let img = image::open(img_path)?;
     let (width, height) = img.dimensions();
-    println!(
-        "Loaded stitched image: {} ({}x{}) in {:.2?}",
+    cv_log_info!(
+        tags::FEATURES2D,
+        "loaded stitched image: {} ({}x{}) in {:.2?}",
         img_path,
         width,
         height,
@@ -88,9 +94,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let half_width = width / 2;
-    println!(
-        "Splitting image into left half ({}x{}) and right half ({}x{})",
-        half_width, height, half_width, height
+    cv_log_debug!(
+        tags::FEATURES2D,
+        "splitting into left ({}x{}) and right ({}x{})",
+        half_width,
+        height,
+        half_width,
+        height
     );
 
     // 2. Convert to RGB Matrix
@@ -123,42 +133,52 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    println!("Cropped images in {:.2?}", crop_start.elapsed());
+    cv_log_debug!(
+        tags::FEATURES2D,
+        "cropped images in {:.2?}",
+        crop_start.elapsed()
+    );
 
     // 5. Detect and Compute ORB Features on both halves (extract 1000 features for higher density)
     let orb = Orb::new(1000, 1.2, 8, 31, 0, 2, ScoreType::Harris, 31, 20);
-    println!("Extracting ORB features on left half...");
+    cv_log_info!(tags::FEATURES2D, "extracting ORB features on left half...");
     let start_left = Instant::now();
     let (kps1, desc1) = orb.detect_and_compute(&left_gray)?;
-    println!(
-        "  Left: extracted {} keypoints in {:.2?}",
+    cv_log_info!(
+        tags::FEATURES2D,
+        "  left: {} keypoints in {:.2?}",
         kps1.len(),
         start_left.elapsed()
     );
 
-    println!("Extracting ORB features on right half...");
+    cv_log_info!(tags::FEATURES2D, "extracting ORB features on right half...");
     let start_right = Instant::now();
     let (kps2, desc2) = orb.detect_and_compute(&right_gray)?;
-    println!(
-        "  Right: extracted {} keypoints in {:.2?}",
+    cv_log_info!(
+        tags::FEATURES2D,
+        "  right: {} keypoints in {:.2?}",
         kps2.len(),
         start_right.elapsed()
     );
 
     // 6. Match features using BFMatcher (Hamming distance with cross-check enabled)
-    println!("Matching features using BFMatcher (NormHamming + Cross Check)...");
+    cv_log_info!(
+        tags::FEATURES2D,
+        "matching features using BFMatcher (NormHamming + Cross Check)..."
+    );
     let match_start = Instant::now();
     let matcher = BFMatcher::new(NormType::NormHamming, true)?;
 
     let mutual_matches = matcher.match_descriptors(&desc1, &desc2)?;
-    println!(
-        "  Matched in {:.2?}. Total mutual matches: {}",
+    cv_log_info!(
+        tags::FEATURES2D,
+        "  matched in {:.2?}, {} mutual matches",
         match_start.elapsed(),
         mutual_matches.len()
     );
 
     // 7. Draw matches with random line colors and no unmatched keypoint clutter
-    println!("Drawing matches...");
+    cv_log_info!(tags::FEATURES2D, "drawing matches...");
     let draw_start = Instant::now();
 
     let matched_img = draw_matches(
@@ -170,8 +190,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None, // Random colors for matches
         None, // Do not draw unmatched keypoints
     )?;
-    println!(
-        "  Drawn matching visualization in {:.2?}",
+    cv_log_debug!(
+        tags::FEATURES2D,
+        "drawn matching visualization in {:.2?}",
         draw_start.elapsed()
     );
 
@@ -185,12 +206,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .ok_or("Failed to construct image buffer from matched matrix data")?;
     DynamicImage::ImageRgb8(img_out).save(out_path)?;
-    println!(
-        "  Saved match visualization to: {} in {:.2?}",
+    cv_log_info!(
+        tags::FEATURES2D,
+        "saved match visualization to: {} in {:.2?}",
         out_path,
         save_start.elapsed()
     );
 
-    println!("\nDone! Run 'cargo run --example match_features' to run again.");
+    cv_log_info!(tags::PURECV, "done!");
     Ok(())
 }

--- a/examples/optical_flow.rs
+++ b/examples/optical_flow.rs
@@ -68,11 +68,13 @@
 //! ```
 
 use image::{DynamicImage, GenericImageView, ImageBuffer, Rgb};
+use purecv::core::logging::tags;
 use purecv::core::types::{Point2f, Size2i, TermCriteria, TermType};
 use purecv::core::Matrix;
 use purecv::imgproc::{cvt_color_rgb_to_gray, good_features_to_track};
 use purecv::version;
 use purecv::video::{calc_optical_flow_pyramid_lk, OPTFLOW_LK_GET_MIN_EIGENVALS};
+use purecv::{cv_log_debug, cv_log_error, cv_log_info, cv_log_warning};
 use std::io::Write;
 use std::path::Path;
 
@@ -81,9 +83,14 @@ const SHIFT_X: usize = 4;
 const SHIFT_Y: usize = 3;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("--- purecv Optical Flow Example (static image) ---");
-    println!("purecv v{}", version::get_version());
-    println!("Simulating motion: +{SHIFT_X} px in x, +{SHIFT_Y} px in y\n");
+    purecv::core::logging::init_basic_logger()?;
+
+    cv_log_info!(tags::PURECV, "--- Optical Flow Example (static image) ---");
+    version::print_version();
+    cv_log_info!(
+        tags::VIDEO,
+        "simulating motion: +{SHIFT_X} px in x, +{SHIFT_Y} px in y"
+    );
 
     // Accept an optional image path from the command line.
     let default_path = "examples/data/butterfly.jpg";
@@ -92,8 +99,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| default_path.to_string());
 
     if !Path::new(&img_path).exists() {
-        eprintln!(
-            "Error: '{}' not found. Run from the project root.",
+        cv_log_error!(
+            tags::VIDEO,
+            "'{}' not found. Run from the project root.",
             img_path
         );
         return Ok(());
@@ -106,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -----------------------------------------------------------------------
     let img = image::open(&img_path)?;
     let (width, height) = img.dimensions();
-    println!("Loaded: {} ({}×{})", img_path, width, height);
+    cv_log_info!(tags::VIDEO, "loaded: {} ({}x{})", img_path, width, height);
 
     let rgb_img = img.to_rgb8();
     let mat_rgb = Matrix::from_vec(
@@ -116,9 +124,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rgb_img.clone().into_raw(),
     );
     let prev_gray = cvt_color_rgb_to_gray(&mat_rgb)?;
-    println!(
-        "Grayscale: {}×{}, {} channel(s)\n",
-        prev_gray.rows, prev_gray.cols, prev_gray.channels
+    cv_log_debug!(
+        tags::VIDEO,
+        "grayscale: {}x{}, {} channel(s)",
+        prev_gray.rows,
+        prev_gray.cols,
+        prev_gray.channels
     );
 
     // -----------------------------------------------------------------------
@@ -141,12 +152,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     let next_gray = Matrix::<u8>::from_vec(rows, cols, 1, next_data);
-    println!("Synthesised next frame: translated by (+{SHIFT_X}, +{SHIFT_Y}) pixels\n");
+    cv_log_debug!(
+        tags::VIDEO,
+        "synthesised next frame: translated by (+{SHIFT_X}, +{SHIFT_Y}) pixels"
+    );
 
     // -----------------------------------------------------------------------
     // 3. Detect good features to track in the previous (original) frame.
     // -----------------------------------------------------------------------
-    println!("=== Step 1: Detect features (goodFeaturesToTrack) ===");
+    cv_log_info!(
+        tags::VIDEO,
+        "=== Step 1: Detect features (goodFeaturesToTrack) ==="
+    );
     let corners = good_features_to_track(&prev_gray, 100, 0.01, 10.0, 3, false, 0.04)?;
     println!("Detected {} corner(s)", corners.len());
     for (i, pt) in corners.iter().take(5).enumerate() {
@@ -157,14 +174,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if corners.is_empty() {
-        eprintln!("\nNo features detected — try a different image.");
+        cv_log_warning!(tags::VIDEO, "no features detected — try a different image.");
         return Ok(());
     }
 
     // -----------------------------------------------------------------------
     // 4. Track features from prev to next using pyramidal LK.
     // -----------------------------------------------------------------------
-    println!("\n=== Step 2: Track features (calcOpticalFlowPyrLK) ===");
+    cv_log_info!(
+        tags::VIDEO,
+        "=== Step 2: Track features (calcOpticalFlowPyrLK) ==="
+    );
     let criteria = TermCriteria::new(TermType::Both, 30, 0.001);
     let (next_pts, status, err) = calc_optical_flow_pyramid_lk(
         &prev_gray,
@@ -271,10 +291,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let csv_path = "examples/data/out/optical_flow_vectors.csv";
     save_flow_csv(&corners, &next_pts, &status, &err, csv_path)?;
 
-    println!("\nOutput saved to:");
-    println!("  {result_path}   (annotated image: green = tracked, red = lost)");
-    println!("  {csv_path}");
-    println!("\nDone.");
+    cv_log_info!(tags::VIDEO, "output saved to:");
+    cv_log_info!(
+        tags::VIDEO,
+        "  {result_path}   (annotated image: green = tracked, red = lost)"
+    );
+    cv_log_info!(tags::VIDEO, "  {csv_path}");
+    cv_log_info!(tags::PURECV, "done.");
     Ok(())
 }
 

--- a/src/calib3d/pose.rs
+++ b/src/calib3d/pose.rs
@@ -41,8 +41,10 @@
 //! (rotation and translation vectors) in the camera coordinate system.
 
 use crate::core::error::{PureCvError, Result};
+use crate::core::logging::tags;
 use crate::core::types::{Point2f, Point3f};
 use crate::core::Matrix;
+use crate::cv_log_warning;
 
 use super::geometry::rvec_to_rmat;
 use super::linalg::{mat3_inv, mat3_mul, nearest_rotation, null_space_vector, Lcg};
@@ -312,6 +314,11 @@ pub fn solve_pnp_ransac(
     }
 
     if !found || best_count < 6 {
+        cv_log_warning!(
+            tags::CALIB3D,
+            "solve_pnp_ransac: pose estimation failed because RANSAC consensus inliers ({}) were below the required minimum of 6 points",
+            best_count
+        );
         return Ok(false);
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -42,6 +42,7 @@ pub mod dct;
 pub mod dft;
 pub mod dynamic;
 pub mod error;
+pub mod logging;
 pub mod matrix;
 pub mod metrics;
 pub mod rng;
@@ -79,6 +80,7 @@ pub use self::dft::{
 };
 pub use self::dynamic::{DynamicData, DynamicMatrix};
 pub use self::error::{PureCvError, Result};
+pub use self::logging::{get_log_level, set_log_level, LogLevel};
 pub use self::matrix::{
     DataType, Depth, MatType, Matrix, CV_16S, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_16U,
     CV_16UC1, CV_16UC2, CV_16UC3, CV_16UC4, CV_32F, CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4, CV_32S,

--- a/src/core.rs
+++ b/src/core.rs
@@ -80,7 +80,7 @@ pub use self::dft::{
 };
 pub use self::dynamic::{DynamicData, DynamicMatrix};
 pub use self::error::{PureCvError, Result};
-pub use self::logging::{get_log_level, set_log_level, LogLevel};
+pub use self::logging::{get_log_level, init_basic_logger, set_log_level, LogLevel};
 pub use self::matrix::{
     DataType, Depth, MatType, Matrix, CV_16S, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_16U,
     CV_16UC1, CV_16UC2, CV_16UC3, CV_16UC4, CV_32F, CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4, CV_32S,

--- a/src/core.rs
+++ b/src/core.rs
@@ -34,6 +34,24 @@
  *
  */
 
+//! Core data structures and numerical routines — the `core` module.
+//!
+//! This module mirrors OpenCV's `core` module and provides the foundational
+//! types and operations the rest of the crate builds on:
+//!
+//! - [`Matrix`] — the row-major, n-channel matrix/image container, together
+//!   with [`MatType`], [`Depth`] and the OpenCV-style type constants.
+//! - [`Scalar`] — a 4-channel per-pixel constant.
+//! - Element-wise and reduction [`arithm`]etic (`add`, `multiply`, `gemm`,
+//!   `norm`, `reduce`, …), plus [`solvers`] and matrix operations.
+//! - `dft`/`dct` frequency transforms, [`rng`] random-number generation,
+//!   [`metrics`] and [`structural`] helpers.
+//! - [`error::PureCvError`] — the crate-wide error type returned as
+//!   [`error::Result`].
+//! - [`logging`] — an OpenCV-compatible structured logging API built on the
+//!   `log` facade, with the `cv_log_*!`, [`crate::cv_bail!`] and
+//!   [`crate::cv_err!`] macros.
+
 pub mod arithm;
 pub mod constants;
 #[cfg(feature = "transforms")]

--- a/src/core.rs
+++ b/src/core.rs
@@ -98,7 +98,10 @@ pub use self::dft::{
 };
 pub use self::dynamic::{DynamicData, DynamicMatrix};
 pub use self::error::{PureCvError, Result};
-pub use self::logging::{get_log_level, init_basic_logger, set_log_level, LogLevel};
+pub use self::logging::{get_log_level, set_log_level, LogLevel};
+// `init_basic_logger` writes to stdout and is only available with `std`.
+#[cfg(feature = "std")]
+pub use self::logging::init_basic_logger;
 pub use self::matrix::{
     DataType, Depth, MatType, Matrix, CV_16S, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_16U,
     CV_16UC1, CV_16UC2, CV_16UC3, CV_16UC4, CV_32F, CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4, CV_32S,

--- a/src/core.rs
+++ b/src/core.rs
@@ -86,6 +86,7 @@ pub use self::matrix::{
     CV_8SC1, CV_8SC2, CV_8SC3, CV_8SC4, CV_8U, CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
 };
 pub use self::metrics::{mahalanobis, psnr};
+#[cfg(feature = "std")]
 pub use self::rng::{rand_shuffle, randn, randu, set_rng_seed};
 pub use self::solvers::{solve_cubic, solve_quadratic};
 pub use self::types::{
@@ -96,6 +97,8 @@ pub use self::types::{
     KMEANS_RANDOM_CENTERS, KMEANS_USE_INITIAL_LABELS, SORT_ASCENDING, SORT_DESCENDING,
     SORT_EVERY_COLUMN, SORT_EVERY_ROW,
 };
+pub use self::utils::border_interpolate;
 #[cfg(not(feature = "parallel"))]
 pub use self::utils::ParIterFallback;
-pub use self::utils::{border_interpolate, get_tick_count, get_tick_frequency};
+#[cfg(feature = "std")]
+pub use self::utils::{get_tick_count, get_tick_frequency};

--- a/src/core/arithm.rs
+++ b/src/core/arithm.rs
@@ -36,8 +36,10 @@
 
 use crate::core::constants::CV_2PI;
 use crate::core::error::{PureCvError, Result};
+use crate::core::logging::tags;
 use crate::core::types::{CmpTypes, NormTypes, ReduceTypes, Scalar};
 use crate::core::{DataType, Matrix};
+use crate::cv_log_warning;
 use num_traits::{Bounded, FromPrimitive, Num, SaturatingAdd, SaturatingSub, ToPrimitive};
 use std::ops::{BitAnd, BitOr, BitXor, Not, Sub};
 
@@ -2252,6 +2254,11 @@ where
         }
 
         if max_abs < 1e-12 {
+            cv_log_warning!(
+                tags::CORE,
+                "solve: linear system solver failed because the matrix is singular or near-singular (pivot max_abs = {:.6e})",
+                max_abs
+            );
             return Ok(false); // Singular matrix
         }
 

--- a/src/core/arithm.rs
+++ b/src/core/arithm.rs
@@ -35,11 +35,12 @@
  */
 
 use crate::core::constants::CV_2PI;
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
 use crate::core::logging::tags;
 use crate::core::types::{CmpTypes, NormTypes, ReduceTypes, Scalar};
 use crate::core::{DataType, Matrix};
 use crate::cv_log_warning;
+use crate::{cv_bail, cv_err};
 use num_traits::{Bounded, FromPrimitive, Num, SaturatingAdd, SaturatingSub, ToPrimitive};
 use std::ops::{BitAnd, BitOr, BitXor, Not, Sub};
 
@@ -394,9 +395,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Bounded + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "add: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -414,9 +423,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Bounded + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "subtract: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -434,9 +451,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Bounded + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "multiply: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -454,9 +479,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Bounded + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "divide: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -480,9 +513,17 @@ where
     T: Copy + Send + Sync + BitAnd<Output = T> + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "bitwise_and: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -500,9 +541,17 @@ where
     T: Copy + Send + Sync + BitOr<Output = T> + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "bitwise_or: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -520,9 +569,17 @@ where
     T: Copy + Send + Sync + BitXor<Output = T> + Default + SimdElement + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "bitwise_xor: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -582,9 +639,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Default + SimdElement + 'static,
 {
     if !src1.dims_match(src2) {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "min: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -602,9 +667,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Default + SimdElement + 'static,
 {
     if !src1.dims_match(src2) {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "max: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -622,9 +695,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Default + SimdElement + 'static,
 {
     if !src1.dims_match(src2) {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "abs_diff: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -681,9 +762,17 @@ where
     T: Copy + Send + Sync + PartialOrd + Default + 'static,
 {
     if !src1.dims_match(src2) {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "compare: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<u8>::new(src1.rows, src1.cols, src1.channels);
@@ -748,9 +837,20 @@ where
         || src.cols != upperb.cols
         || src.channels != upperb.channels
     {
-        return Err(PureCvError::InvalidInput(
-            "Size or channels mismatch".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "in_range: size or channels mismatch (src {}×{}×{}, lowerb {}×{}×{}, upperb {}×{}×{})",
+            src.rows,
+            src.cols,
+            src.channels,
+            lowerb.rows,
+            lowerb.cols,
+            lowerb.channels,
+            upperb.rows,
+            upperb.cols,
+            upperb.channels
+        );
     }
 
     dst.create(src.rows, src.cols, 1);
@@ -807,9 +907,15 @@ where
     T: DataType + PartialOrd + Default + Copy + Sync + Send,
 {
     if lowerb.len() < src.channels || upperb.len() < src.channels {
-        return Err(PureCvError::InvalidInput(
-            "Scalars must have at least as many elements as src channels".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "in_range_scalar: scalars must have at least as many elements as src channels \
+             (src channels = {}, lowerb = {}, upperb = {})",
+            src.channels,
+            lowerb.len(),
+            upperb.len()
+        );
     }
 
     dst.create(src.rows, src.cols, 1);
@@ -867,9 +973,17 @@ where
     T: Num + Copy + Send + Sync + PartialOrd + Sub<Output = T> + Default + SimdElement + 'static,
 {
     if !src1.dims_match(src2) {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "absdiff: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -1126,10 +1240,12 @@ where
                 Ok(sq_sum.sqrt())
             }
         }
-        _ => Err(PureCvError::NotImplemented(format!(
-            "Norm type {:?} is not implemented",
+        _ => Err(cv_err!(
+            tags::CORE,
+            NotImplemented,
+            "norm: norm type {:?} is not implemented",
             norm_type
-        ))),
+        )),
     }
 }
 
@@ -1275,11 +1391,11 @@ where
                 }
             }
         }
-        _ => {
-            return Err(PureCvError::NotImplemented(
-                "Requested normalization type is not implemented yet".to_string(),
-            ))
-        }
+        _ => cv_bail!(
+            tags::CORE,
+            NotImplemented,
+            "normalize: requested normalization type is not implemented yet"
+        ),
     }
     Ok(())
 }
@@ -1306,7 +1422,12 @@ where
     } else if dim == 1 {
         (src.rows, 1)
     } else {
-        return Err(PureCvError::InvalidInput("dim must be 0 or 1".to_string()));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "reduce: dim must be 0 or 1, got {}",
+            dim
+        );
     };
 
     let mut dst_data = vec![T::default(); rows * cols * src.channels];
@@ -1412,9 +1533,12 @@ where
     T: Num + Copy + Send + Sync + 'static,
 {
     if src.channels != 1 {
-        return Err(PureCvError::InvalidInput(
-            "countNonZero requires single-channel matrix".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "count_non_zero: requires a single-channel matrix, got {} channels",
+            src.channels
+        );
     }
     #[cfg(feature = "parallel")]
     {
@@ -1509,9 +1633,17 @@ where
         + 'static,
 {
     if src1.rows != src2.rows || src1.cols != src2.cols || src1.channels != src2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "add_weighted: matrices must have the same dimensions (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src1.rows, src1.cols, src1.channels);
@@ -1701,10 +1833,15 @@ where
     };
 
     if k1 != k2 {
-        return Err(PureCvError::InvalidDimensions(format!(
-            "Incompatible dimensions for GEMM: {}x{} and {}x{}",
-            m, k1, k2, n
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "gemm: incompatible dimensions {}x{} and {}x{}",
+            m,
+            k1,
+            k2,
+            n
+        );
     }
 
     let k = k1;
@@ -1885,9 +2022,13 @@ where
     T: Num + Copy + Send + Sync + ToPrimitive + Default + SimdElement + 'static,
 {
     if src1.data.len() != src2.data.len() {
-        return Err(PureCvError::InvalidDimensions(
-            "Matrices must have the same number of elements".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "dot: matrices must have the same number of elements ({} vs {})",
+            src1.data.len(),
+            src2.data.len()
+        );
     }
 
     #[cfg(feature = "simd")]
@@ -1953,9 +2094,13 @@ where
     let len2 = src2.rows * src2.cols * src2.channels;
 
     if len1 != 3 || len2 != 3 {
-        return Err(PureCvError::InvalidDimensions(
-            "Cross product requires 3-element vectors".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "cross: cross product requires 3-element vectors (got {} and {})",
+            len1,
+            len2
+        );
     }
 
     let min_rows_cols = if src1.rows == 3 {
@@ -2160,9 +2305,14 @@ where
     T: Num + Copy + Send + Sync + ToPrimitive + Default + 'static,
 {
     if src.rows != src.cols || src.channels != 1 {
-        return Err(PureCvError::InvalidDimensions(
-            "Inverse only supports single-channel square matrices".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "invert: only single-channel square matrices are supported (got {}×{}×{})",
+            src.rows,
+            src.cols,
+            src.channels
+        );
     }
 
     let n = src.rows;
@@ -2215,15 +2365,26 @@ where
 {
     if src1.rows != src1.cols || src1.channels != 1 || src2.channels != 1 || src1.rows != src2.rows
     {
-        return Err(PureCvError::InvalidDimensions(
-            "Linear system solver requires compatible single-channel matrices".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "solve: requires compatible single-channel matrices (src1 {}×{}×{}, src2 {}×{}×{})",
+            src1.rows,
+            src1.cols,
+            src1.channels,
+            src2.rows,
+            src2.cols,
+            src2.channels
+        );
     }
 
     if flags != DecompTypes::DECOMP_LU {
-        return Err(PureCvError::NotImplemented(
-            "Only DECOMP_LU is currently supported".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            NotImplemented,
+            "solve: only DECOMP_LU is currently supported, got {:?}",
+            flags
+        );
     }
 
     let n = src1.rows;
@@ -2331,9 +2492,17 @@ where
         + 'static,
 {
     if !x.dims_match(y) {
-        return Err(PureCvError::InvalidDimensions(
-            "x and y must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "magnitude: x and y must have the same dimensions (x {}×{}×{}, y {}×{}×{})",
+            x.rows,
+            x.cols,
+            x.channels,
+            y.rows,
+            y.cols,
+            y.channels
+        );
     }
 
     dst.create(x.rows, x.cols, x.channels);
@@ -2399,9 +2568,17 @@ where
     T: DataType + ToPrimitive + FromPrimitive + Default + Copy + Send + Sync + 'static,
 {
     if !x.dims_match(y) {
-        return Err(PureCvError::InvalidDimensions(
-            "x and y must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "phase: x and y must have the same dimensions (x {}×{}×{}, y {}×{}×{})",
+            x.rows,
+            x.cols,
+            x.channels,
+            y.rows,
+            y.cols,
+            y.channels
+        );
     }
 
     angle.create(x.rows, x.cols, x.channels);
@@ -2473,9 +2650,17 @@ where
     T: DataType + ToPrimitive + FromPrimitive + Default + Copy + Send + Sync + 'static,
 {
     if !x.dims_match(y) {
-        return Err(PureCvError::InvalidDimensions(
-            "x and y must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "cart_to_polar: x and y must have the same dimensions (x {}×{}×{}, y {}×{}×{})",
+            x.rows,
+            x.cols,
+            x.channels,
+            y.rows,
+            y.cols,
+            y.channels
+        );
     }
 
     mag.create(x.rows, x.cols, x.channels);
@@ -2550,9 +2735,18 @@ where
     T: DataType + ToPrimitive + FromPrimitive + Default + Copy + Send + Sync + 'static,
 {
     if !mag.dims_match(ang) {
-        return Err(PureCvError::InvalidDimensions(
-            "magnitude and angle must have the same dimensions".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "polar_to_cart: magnitude and angle must have the same dimensions \
+             (mag {}×{}×{}, ang {}×{}×{})",
+            mag.rows,
+            mag.cols,
+            mag.channels,
+            ang.rows,
+            ang.cols,
+            ang.channels
+        );
     }
 
     x.create(mag.rows, mag.cols, mag.channels);
@@ -2625,9 +2819,12 @@ where
     T: Default + Clone + Copy + FromPrimitive + ToPrimitive + Send + Sync + 'static,
 {
     if m.channels != 1 {
-        return Err(PureCvError::InvalidDimensions(
-            "transformation matrix must be single-channel".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "transform: transformation matrix must be single-channel, got {} channels",
+            m.channels
+        );
     }
 
     let scn = src.channels;
@@ -2636,10 +2833,15 @@ where
 
     // m must be dcn × scn  OR  dcn × (scn + 1)  (affine)
     if m_cols != scn && m_cols != scn + 1 {
-        return Err(PureCvError::InvalidDimensions(format!(
-            "transformation matrix columns ({}) must equal src channels ({}) or src channels + 1 ({})",
-            m_cols, scn, scn + 1
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "transform: transformation matrix columns ({}) must equal src channels ({}) \
+             or src channels + 1 ({})",
+            m_cols,
+            scn,
+            scn + 1
+        );
     }
 
     let affine = m_cols == scn + 1;
@@ -2715,23 +2917,35 @@ where
     let scn = src.channels;
 
     if scn != 2 && scn != 3 {
-        return Err(PureCvError::InvalidDimensions(
-            "perspectiveTransform requires 2- or 3-channel input".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "perspective_transform: requires 2- or 3-channel input, got {} channels",
+            scn
+        );
     }
 
     if m.channels != 1 {
-        return Err(PureCvError::InvalidDimensions(
-            "transformation matrix must be single-channel".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "perspective_transform: transformation matrix must be single-channel, got {} channels",
+            m.channels
+        );
     }
 
     let n = scn + 1; // homogeneous dimension
     if m.rows != n || m.cols != n {
-        return Err(PureCvError::InvalidDimensions(format!(
-            "transformation matrix must be {}x{} for {}-channel input, got {}x{}",
-            n, n, scn, m.rows, m.cols
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "perspective_transform: transformation matrix must be {}x{} for {}-channel input, got {}x{}",
+            n,
+            n,
+            scn,
+            m.rows,
+            m.cols
+        );
     }
 
     dst.create(src.rows, src.cols, scn);
@@ -2820,14 +3034,20 @@ pub fn solve_poly(coeffs: &Matrix<f64>, roots: &mut Matrix<f64>, max_iters: i32)
     // Flatten coefficients into a slice
     let total = coeffs.rows * coeffs.cols * coeffs.channels;
     if total < 2 {
-        return Err(PureCvError::InvalidInput(
-            "solvePoly requires at least 2 coefficients (degree >= 1)".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "solve_poly: requires at least 2 coefficients (degree >= 1), got {}",
+            total
+        );
     }
     if coeffs.channels != 1 {
-        return Err(PureCvError::InvalidInput(
-            "solvePoly requires single-channel coefficient matrix".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "solve_poly: requires a single-channel coefficient matrix, got {} channels",
+            coeffs.channels
+        );
     }
 
     let c = &coeffs.data;
@@ -2836,9 +3056,12 @@ pub fn solve_poly(coeffs: &Matrix<f64>, roots: &mut Matrix<f64>, max_iters: i32)
     // Normalise so that c[n] == 1 (monic)
     let lead = c[n];
     if lead.abs() < f64::EPSILON {
-        return Err(PureCvError::InvalidInput(
-            "Leading coefficient is zero".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "solve_poly: leading coefficient is zero ({:e})",
+            lead
+        );
     }
     let a: Vec<f64> = c.iter().map(|&v| v / lead).collect();
 
@@ -2966,9 +3189,12 @@ where
     T: Default + Clone + Copy + PartialOrd + Send + Sync + 'static,
 {
     if src.channels != 1 {
-        return Err(PureCvError::InvalidInput(
-            "sort requires single-channel matrix".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "sort: requires a single-channel matrix, got {} channels",
+            src.channels
+        );
     }
     dst.rows = src.rows;
     dst.cols = src.cols;
@@ -3016,9 +3242,12 @@ where
     T: Default + Clone + Copy + PartialOrd + Send + Sync + 'static,
 {
     if src.channels != 1 {
-        return Err(PureCvError::InvalidInput(
-            "sortIdx requires single-channel matrix".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "sort_idx: requires a single-channel matrix, got {} channels",
+            src.channels
+        );
     }
     dst.rows = src.rows;
     dst.cols = src.cols;
@@ -3103,10 +3332,13 @@ pub fn kmeans(
     let dims = data.cols * data.channels; // dimensionality
 
     if k <= 0 || (k as usize) > n {
-        return Err(PureCvError::InvalidInput(format!(
-            "k ({}) must be in [1, {}]",
-            k, n
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "kmeans: k ({}) must be in [1, {}]",
+            k,
+            n
+        );
     }
     let k = k as usize;
 
@@ -3485,18 +3717,23 @@ where
 {
     let lut_entries = lut_table.rows * lut_table.cols;
     if lut_entries != 256 {
-        return Err(PureCvError::InvalidInput(format!(
-            "LUT must have exactly 256 entries, got {}",
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "lut: LUT must have exactly 256 entries, got {}",
             lut_entries
-        )));
+        );
     }
     let lut_cn = lut_table.channels;
     let src_cn = src.channels;
     if lut_cn != 1 && lut_cn != src_cn {
-        return Err(PureCvError::IncompatibleChannels(format!(
-            "LUT channels ({}) must be 1 or match source channels ({})",
-            lut_cn, src_cn
-        )));
+        cv_bail!(
+            tags::CORE,
+            IncompatibleChannels,
+            "lut: LUT channels ({}) must be 1 or match source channels ({})",
+            lut_cn,
+            src_cn
+        );
     }
 
     let total = src.rows * src.cols * src_cn;

--- a/src/core/arithm.rs
+++ b/src/core/arithm.rs
@@ -34,12 +34,19 @@
  *
  */
 
+// `num_traits::Float` provides `sqrt`, `sin`, ... on `f32`/`f64` via libm
+// when `std` is disabled; with `std` the inherent methods win, so the
+// import is only "used" in no_std builds.
+use alloc::{format, string::ToString, vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::constants::CV_2PI;
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::{CmpTypes, NormTypes, ReduceTypes, Scalar};
 use crate::core::{DataType, Matrix};
+use core::ops::{BitAnd, BitOr, BitXor, Not, Sub};
 use num_traits::{Bounded, FromPrimitive, Num, SaturatingAdd, SaturatingSub, ToPrimitive};
-use std::ops::{BitAnd, BitOr, BitXor, Not, Sub};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -64,7 +71,7 @@ macro_rules! binary_op {
         #[cfg(feature = "simd")]
         {
             // SIMD fast-path: only when dst type == src type and type has SIMD support
-            if std::any::TypeId::of::<$t_dst>() == std::any::TypeId::of::<$t_src>()
+            if core::any::TypeId::of::<$t_dst>() == core::any::TypeId::of::<$t_src>()
                 && <$t_src as SimdElement>::has_simd()
             {
                 // Try the SIMD kernel. If it returns false, fall back to scalar.
@@ -73,7 +80,7 @@ macro_rules! binary_op {
                 #[cfg(feature = "parallel")]
                 {
                     use rayon::prelude::*;
-                    use std::sync::atomic::{AtomicBool, Ordering};
+                    use core::sync::atomic::{AtomicBool, Ordering};
 
                     let chunk_size = ($dst.data.len() / rayon::current_num_threads()).max(1024);
                     let all_ok = AtomicBool::new(true);
@@ -87,7 +94,7 @@ macro_rules! binary_op {
                             // Transmute the dst chunk to $t_src for the SIMD call
                             // This is safe because we verified $t_dst == $t_src above
                             let dst_as_src: &mut [$t_src] = unsafe {
-                                std::slice::from_raw_parts_mut(
+                                core::slice::from_raw_parts_mut(
                                     dst_chunk.as_mut_ptr() as *mut $t_src,
                                     len,
                                 )
@@ -107,7 +114,7 @@ macro_rules! binary_op {
                 #[cfg(not(feature = "parallel"))]
                 {
                     let dst_as_src: &mut [$t_src] = unsafe {
-                        std::slice::from_raw_parts_mut(
+                        core::slice::from_raw_parts_mut(
                             $dst.data.as_mut_ptr() as *mut $t_src,
                             $dst.data.len(),
                         )
@@ -215,7 +222,7 @@ macro_rules! unary_op {
     ($dst:expr, $src:expr, $t_dst:ty, $t_src:ty, |$d:ident, $s:ident| $body:expr, simd: $simd_fn:ident) => {
         #[cfg(feature = "simd")]
         {
-            if std::any::TypeId::of::<$t_dst>() == std::any::TypeId::of::<$t_src>()
+            if core::any::TypeId::of::<$t_dst>() == core::any::TypeId::of::<$t_src>()
                 && <$t_src as SimdElement>::has_simd()
             {
                 // Try the SIMD kernel. If it returns false, fall back to scalar.
@@ -224,7 +231,7 @@ macro_rules! unary_op {
                 #[cfg(feature = "parallel")]
                 {
                     use rayon::prelude::*;
-                    use std::sync::atomic::{AtomicBool, Ordering};
+                    use core::sync::atomic::{AtomicBool, Ordering};
 
                     let chunk_size = ($dst.data.len() / rayon::current_num_threads()).max(1024);
                     let all_ok = AtomicBool::new(true);
@@ -236,7 +243,7 @@ macro_rules! unary_op {
                             let offset = idx * chunk_size;
                             let len = dst_chunk.len();
                             let dst_as_src: &mut [$t_src] = unsafe {
-                                std::slice::from_raw_parts_mut(
+                                core::slice::from_raw_parts_mut(
                                     dst_chunk.as_mut_ptr() as *mut $t_src,
                                     len,
                                 )
@@ -255,7 +262,7 @@ macro_rules! unary_op {
                 #[cfg(not(feature = "parallel"))]
                 {
                     let dst_as_src: &mut [$t_src] = unsafe {
-                        std::slice::from_raw_parts_mut(
+                        core::slice::from_raw_parts_mut(
                             $dst.data.as_mut_ptr() as *mut $t_src,
                             $dst.data.len(),
                         )
@@ -1517,8 +1524,8 @@ where
     #[cfg(feature = "simd")]
     {
         // Only f32/f64 have simd_add_weighted; u8 and others use the scalar fallback.
-        if (std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>()
-            || std::any::TypeId::of::<T>() == std::any::TypeId::of::<f64>())
+        if (core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>()
+            || core::any::TypeId::of::<T>() == core::any::TypeId::of::<f64>())
             && <T as SimdElement>::has_simd()
         {
             <T>::simd_add_weighted(&mut dst.data, &src1.data, &src2.data, alpha, beta, gamma);
@@ -1647,8 +1654,8 @@ where
     #[cfg(feature = "simd")]
     {
         // Only f32/f64 have simd_convert_scale_abs; others use the scalar fallback.
-        if (std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>()
-            || std::any::TypeId::of::<T>() == std::any::TypeId::of::<f64>())
+        if (core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>()
+            || core::any::TypeId::of::<T>() == core::any::TypeId::of::<f64>())
             && <T as SimdElement>::has_simd()
         {
             <T>::simd_convert_scale_abs(&mut dst.data, &src.data, alpha, beta);
@@ -1817,7 +1824,7 @@ where
     T: Num + Copy + Send + Sync + Default + 'static,
 {
     mtx.data.fill(T::zero());
-    let n = std::cmp::min(mtx.rows, mtx.cols);
+    let n = core::cmp::min(mtx.rows, mtx.cols);
     let channels = mtx.channels;
     let cols = mtx.cols;
 
@@ -1891,8 +1898,8 @@ where
     #[cfg(feature = "simd")]
     {
         // Only f32/f64 have simd_dot; others use the scalar fallback.
-        if (std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>()
-            || std::any::TypeId::of::<T>() == std::any::TypeId::of::<f64>())
+        if (core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>()
+            || core::any::TypeId::of::<T>() == core::any::TypeId::of::<f64>())
             && <T as SimdElement>::has_simd()
         {
             if let Some(result) = <T>::simd_dot(&src1.data, &src2.data) {
@@ -1996,7 +2003,7 @@ pub fn trace<T>(src: &Matrix<T>) -> Scalar<f64>
 where
     T: Num + Copy + Send + Sync + ToPrimitive + Default + 'static,
 {
-    let n = std::cmp::min(src.rows, src.cols);
+    let n = core::cmp::min(src.rows, src.cols);
     let channels = src.channels;
     let cols = src.cols;
     let mut sum = [0.0; 4];
@@ -2334,8 +2341,8 @@ where
     #[cfg(feature = "simd")]
     {
         // Only f32/f64 have simd_magnitude; others use the scalar fallback.
-        if (std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>()
-            || std::any::TypeId::of::<T>() == std::any::TypeId::of::<f64>())
+        if (core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>()
+            || core::any::TypeId::of::<T>() == core::any::TypeId::of::<f64>())
             && <T as SimdElement>::has_simd()
         {
             <T>::simd_magnitude(&mut dst.data, &x.data, &y.data);
@@ -2977,7 +2984,7 @@ where
             let start = r * dst.cols;
             let end = start + dst.cols;
             let row = &mut dst.data[start..end];
-            row.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            row.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
             if descending {
                 row.reverse();
             }
@@ -2986,7 +2993,7 @@ where
         // Sort every column: extract column, sort, put back
         for c in 0..dst.cols {
             let mut col: Vec<T> = (0..dst.rows).map(|r| dst.data[r * dst.cols + c]).collect();
-            col.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            col.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
             if descending {
                 col.reverse();
             }
@@ -3028,7 +3035,7 @@ where
             indices.sort_by(|&a, &b| {
                 src.data[start + a]
                     .partial_cmp(&src.data[start + b])
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .unwrap_or(core::cmp::Ordering::Equal)
             });
             if descending {
                 indices.reverse();
@@ -3043,7 +3050,7 @@ where
             indices.sort_by(|&a, &b| {
                 src.data[a * src.cols + c]
                     .partial_cmp(&src.data[b * src.cols + c])
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .unwrap_or(core::cmp::Ordering::Equal)
             });
             if descending {
                 indices.reverse();

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -36,32 +36,32 @@
 
 //! Mathematical constants mirroring OpenCV's C++ `CV_PI`, `CV_2PI`, etc.
 //!
-//! All values are `pub const f64` backed by [`std::f64::consts`] for
+//! All values are `pub const f64` backed by [`core::f64::consts`] for
 //! maximum precision and cross-platform reproducibility.
 
-/// Pi (same as `std::f64::consts::PI`).
-pub const CV_PI: f64 = std::f64::consts::PI;
+/// Pi (same as `core::f64::consts::PI`).
+pub const CV_PI: f64 = core::f64::consts::PI;
 
-/// Pi divided by 2 (same as `std::f64::consts::FRAC_PI_2`).
-pub const CV_PI_2: f64 = std::f64::consts::FRAC_PI_2;
+/// Pi divided by 2 (same as `core::f64::consts::FRAC_PI_2`).
+pub const CV_PI_2: f64 = core::f64::consts::FRAC_PI_2;
 
 /// 2 * Pi — full circle in radians.
-pub const CV_2PI: f64 = 2.0 * std::f64::consts::PI;
+pub const CV_2PI: f64 = 2.0 * core::f64::consts::PI;
 
-/// Pi divided by 4 (same as `std::f64::consts::FRAC_PI_4`).
-pub const CV_PI_4: f64 = std::f64::consts::FRAC_PI_4;
+/// Pi divided by 4 (same as `core::f64::consts::FRAC_PI_4`).
+pub const CV_PI_4: f64 = core::f64::consts::FRAC_PI_4;
 
-/// Log base 2 of e (same as `std::f64::consts::LOG2_E`).
-pub const CV_LOG2: f64 = std::f64::consts::LOG2_E;
+/// Log base 2 of e (same as `core::f64::consts::LOG2_E`).
+pub const CV_LOG2: f64 = core::f64::consts::LOG2_E;
 
-/// Natural logarithm of 2 (same as `std::f64::consts::LN_2`).
-pub const CV_LN2: f64 = std::f64::consts::LN_2;
+/// Natural logarithm of 2 (same as `core::f64::consts::LN_2`).
+pub const CV_LN2: f64 = core::f64::consts::LN_2;
 
-/// Square root of 2 (same as `std::f64::consts::SQRT_2`).
-pub const CV_SQRT2: f64 = std::f64::consts::SQRT_2;
+/// Square root of 2 (same as `core::f64::consts::SQRT_2`).
+pub const CV_SQRT2: f64 = core::f64::consts::SQRT_2;
 
-/// Euler's number (same as `std::f64::consts::E`).
-pub const CV_E: f64 = std::f64::consts::E;
+/// Euler's number (same as `core::f64::consts::E`).
+pub const CV_E: f64 = core::f64::consts::E;
 
-/// Natural logarithm of 10 (same as `std::f64::consts::LN_10`).
-pub const CV_LN10: f64 = std::f64::consts::LN_10;
+/// Natural logarithm of 10 (same as `core::f64::consts::LN_10`).
+pub const CV_LN10: f64 = core::f64::consts::LN_10;

--- a/src/core/dct.rs
+++ b/src/core/dct.rs
@@ -35,8 +35,10 @@
  */
 
 use crate::core::constants::CV_PI;
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::matrix::Matrix;
+use crate::cv_bail;
 
 /// Discrete Cosine Transform.
 /// Currently implemented using a straightforward algorithm.
@@ -45,18 +47,25 @@ where
     T: Copy + Into<f64>,
 {
     if src.channels != 1 {
-        return Err(PureCvError::InvalidInput(
-            "DCT only supports 1-channel images".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "dct: only 1-channel images are supported, got {} channels",
+            src.channels
+        );
     }
 
     let rows = src.rows;
     let cols = src.cols;
 
     if rows == 0 || cols == 0 {
-        return Err(PureCvError::InvalidDimensions(
-            "Input must not be empty".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "dct: input must not be empty ({}×{})",
+            rows,
+            cols
+        );
     }
 
     let n = rows * cols;
@@ -131,18 +140,25 @@ where
     T: Copy + Into<f64>,
 {
     if src.channels != 1 {
-        return Err(PureCvError::InvalidInput(
-            "IDCT only supports 1-channel images".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "idct: only 1-channel images are supported, got {} channels",
+            src.channels
+        );
     }
 
     let rows = src.rows;
     let cols = src.cols;
 
     if rows == 0 || cols == 0 {
-        return Err(PureCvError::InvalidDimensions(
-            "Input must not be empty".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "idct: input must not be empty ({}×{})",
+            rows,
+            cols
+        );
     }
 
     let n = rows * cols;

--- a/src/core/dct.rs
+++ b/src/core/dct.rs
@@ -34,6 +34,8 @@
  *
  */
 
+use alloc::vec;
+
 use crate::core::constants::CV_PI;
 use crate::core::error::{PureCvError, Result};
 use crate::core::matrix::Matrix;

--- a/src/core/dft.rs
+++ b/src/core/dft.rs
@@ -37,8 +37,10 @@
 use rustfft::num_complex::Complex;
 use rustfft::FftPlanner;
 
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::matrix::Matrix;
+use crate::cv_bail;
 
 // ---------------------------------------------------------------------------
 // DFT flag constants (matching OpenCV values)
@@ -172,15 +174,20 @@ pub fn dft<T: DftFloat>(src: &Matrix<T>, flags: i32, nonzero_rows: usize) -> Res
     let want_real_output = (flags & DFT_REAL_OUTPUT) != 0;
 
     if src.channels != 1 && src.channels != 2 {
-        return Err(PureCvError::InvalidInput(
-            "dft requires 1-channel (real) or 2-channel (complex) input".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "dft: requires 1-channel (real) or 2-channel (complex) input, got {} channels",
+            src.channels
+        );
     }
 
     if want_real_output && want_complex_output {
-        return Err(PureCvError::InvalidInput(
-            "DFT_REAL_OUTPUT and DFT_COMPLEX_OUTPUT are mutually exclusive".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "dft: DFT_REAL_OUTPUT and DFT_COMPLEX_OUTPUT are mutually exclusive"
+        );
     }
 
     let is_complex_input = src.channels == 2;
@@ -188,9 +195,13 @@ pub fn dft<T: DftFloat>(src: &Matrix<T>, flags: i32, nonzero_rows: usize) -> Res
     let cols = src.cols;
 
     if rows == 0 || cols == 0 {
-        return Err(PureCvError::InvalidDimensions(
-            "dft input must not be empty".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "dft: input must not be empty ({}×{})",
+            rows,
+            cols
+        );
     }
 
     let active_rows = if nonzero_rows > 0 && nonzero_rows < rows {

--- a/src/core/dft.rs
+++ b/src/core/dft.rs
@@ -34,6 +34,8 @@
  *
  */
 
+use alloc::vec;
+
 use rustfft::num_complex::Complex;
 use rustfft::FftPlanner;
 

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -34,8 +34,10 @@
  *
  */
 
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::matrix::{Depth, MatType, Matrix};
+use crate::cv_bail;
 
 /// An enum bridging type-erased dynamic usage to strongly typed generic `Matrix<T>`.
 #[derive(Debug, Clone, PartialEq)]
@@ -101,9 +103,7 @@ impl DynamicMatrix {
             Depth::CV_32F => DynamicData::F32(Matrix::from_vec(rows, cols, ch, vec![0f32; n])),
             Depth::CV_64F => DynamicData::F64(Matrix::from_vec(rows, cols, ch, vec![0f64; n])),
             Depth::CV_16F => {
-                return Err(PureCvError::InvalidInput(
-                    "CV_16F is not yet supported".into(),
-                ))
+                cv_bail!(tags::CORE, InvalidInput, "new: CV_16F is not yet supported")
             }
         };
         Ok(Self { data })
@@ -132,9 +132,11 @@ impl DynamicMatrix {
             Depth::CV_32F => DynamicData::F32(Matrix::from_vec(rows, cols, ch, vec![1f32; n])),
             Depth::CV_64F => DynamicData::F64(Matrix::from_vec(rows, cols, ch, vec![1f64; n])),
             Depth::CV_16F => {
-                return Err(PureCvError::InvalidInput(
-                    "CV_16F is not yet supported".into(),
-                ))
+                cv_bail!(
+                    tags::CORE,
+                    InvalidInput,
+                    "ones: CV_16F is not yet supported"
+                )
             }
         };
         Ok(Self { data })
@@ -152,14 +154,16 @@ impl DynamicMatrix {
     pub fn new_u8(rows: usize, cols: usize, channels: usize, data: Vec<u8>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_u8: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::U8(Matrix::from_vec(rows, cols, channels, data)),
@@ -173,14 +177,16 @@ impl DynamicMatrix {
     pub fn new_i8(rows: usize, cols: usize, channels: usize, data: Vec<i8>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_i8: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::I8(Matrix::from_vec(rows, cols, channels, data)),
@@ -194,14 +200,16 @@ impl DynamicMatrix {
     pub fn new_u16(rows: usize, cols: usize, channels: usize, data: Vec<u16>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_u16: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::U16(Matrix::from_vec(rows, cols, channels, data)),
@@ -215,14 +223,16 @@ impl DynamicMatrix {
     pub fn new_i16(rows: usize, cols: usize, channels: usize, data: Vec<i16>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_i16: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::I16(Matrix::from_vec(rows, cols, channels, data)),
@@ -236,14 +246,16 @@ impl DynamicMatrix {
     pub fn new_i32(rows: usize, cols: usize, channels: usize, data: Vec<i32>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_i32: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::I32(Matrix::from_vec(rows, cols, channels, data)),
@@ -257,14 +269,16 @@ impl DynamicMatrix {
     pub fn new_f32(rows: usize, cols: usize, channels: usize, data: Vec<f32>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_f32: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::F32(Matrix::from_vec(rows, cols, channels, data)),
@@ -278,14 +292,16 @@ impl DynamicMatrix {
     pub fn new_f64(rows: usize, cols: usize, channels: usize, data: Vec<f64>) -> Result<Self> {
         let expected = rows * cols * channels;
         if data.len() != expected {
-            return Err(PureCvError::InvalidInput(format!(
-                "Data length {} does not match {}×{}×{} = {}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_f64: data length {} does not match {}×{}×{} = {}",
                 data.len(),
                 rows,
                 cols,
                 channels,
                 expected
-            )));
+            );
         }
         Ok(Self {
             data: DynamicData::F64(Matrix::from_vec(rows, cols, channels, data)),

--- a/src/core/dynamic.rs
+++ b/src/core/dynamic.rs
@@ -34,6 +34,8 @@
  *
  */
 
+use alloc::{format, vec, vec::Vec};
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::matrix::{Depth, MatType, Matrix};
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -34,7 +34,9 @@
  *
  */
 
-use std::fmt;
+use alloc::string::String;
+
+use core::fmt;
 
 /// Custom error type for the purecv library.
 #[derive(Debug, Clone, PartialEq)]
@@ -60,7 +62,7 @@ impl fmt::Display for PureCvError {
     }
 }
 
-impl std::error::Error for PureCvError {}
+impl core::error::Error for PureCvError {}
 
 /// Standard result type for purecv.
-pub type Result<T> = std::result::Result<T, PureCvError>;
+pub type Result<T> = core::result::Result<T, PureCvError>;

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -433,3 +433,72 @@ macro_rules! cv_log_if_debug {
         }
     };
 }
+
+// ── Log-and-return helpers ─────────────────────────────────────────
+//
+// These fuse "log the failure with the caller's subsystem tag" and
+// "produce the corresponding `PureCvError`" into a single call, so every
+// error site stays a one-liner while the log level and format policy live
+// in exactly one place. Use `cv_bail!` in statement position (it expands to
+// a `return`) and `cv_err!` where a `PureCvError` *value* is needed (e.g. a
+// match arm returning `Err(..)`). The `_debug` variants log at debug level
+// for low-severity paths (e.g. `NotImplemented`, degenerate inputs).
+
+/// Log a **warning** with `$tag`, then `return Err(PureCvError::$variant(msg))`.
+///
+/// `$variant` is a bare `PureCvError` variant name (e.g. `InvalidDimensions`);
+/// the remaining arguments are formatted like `format!`.
+///
+/// # Example
+///
+/// ```rust
+/// use purecv::core::logging::tags;
+/// use purecv::core::error::{PureCvError, Result};
+/// fn add(a: usize, b: usize) -> Result<usize> {
+///     if a != b {
+///         purecv::cv_bail!(tags::CORE, InvalidDimensions, "add: {} != {}", a, b);
+///     }
+///     Ok(a + b)
+/// }
+/// assert!(add(1, 2).is_err());
+/// ```
+#[macro_export]
+macro_rules! cv_bail {
+    ($tag:expr, $variant:ident, $($arg:tt)+) => {{
+        let __msg = format!($($arg)+);
+        $crate::cv_log_warning!($tag, "{}", __msg);
+        return Err($crate::core::error::PureCvError::$variant(__msg));
+    }};
+}
+
+/// Like [`cv_bail!`] but yields the `PureCvError` **value** instead of returning.
+///
+/// Use in expression position, e.g. `Err(cv_err!(tags::CORE, NotImplemented, "..."))`.
+#[macro_export]
+macro_rules! cv_err {
+    ($tag:expr, $variant:ident, $($arg:tt)+) => {{
+        let __msg = format!($($arg)+);
+        $crate::cv_log_warning!($tag, "{}", __msg);
+        $crate::core::error::PureCvError::$variant(__msg)
+    }};
+}
+
+/// Like [`cv_bail!`] but logs at **debug** level (for low-severity paths).
+#[macro_export]
+macro_rules! cv_bail_debug {
+    ($tag:expr, $variant:ident, $($arg:tt)+) => {{
+        let __msg = format!($($arg)+);
+        $crate::cv_log_debug!($tag, "{}", __msg);
+        return Err($crate::core::error::PureCvError::$variant(__msg));
+    }};
+}
+
+/// Like [`cv_err!`] but logs at **debug** level (for low-severity paths).
+#[macro_export]
+macro_rules! cv_err_debug {
+    ($tag:expr, $variant:ident, $($arg:tt)+) => {{
+        let __msg = format!($($arg)+);
+        $crate::cv_log_debug!($tag, "{}", __msg);
+        $crate::core::error::PureCvError::$variant(__msg)
+    }};
+}

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -186,8 +186,15 @@ pub fn get_log_level() -> LogLevel {
     LogLevel::from(log::max_level())
 }
 
+// The built-in logger writes to stdout via `println!`, which requires `std`.
+// Under `no_std` there is no stdout to write to, so consumers must install
+// their own `log` backend (e.g. `defmt`/`semihosting`) instead. Everything
+// else in this module (the macros, `LogLevel`, `set_log_level`) is
+// `core`/`alloc`-only and works without `std`.
+#[cfg(feature = "std")]
 struct SimpleLogger;
 
+#[cfg(feature = "std")]
 impl log::Log for SimpleLogger {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
         metadata.level() <= log::max_level()
@@ -207,6 +214,7 @@ impl log::Log for SimpleLogger {
     fn flush(&self) {}
 }
 
+#[cfg(feature = "std")]
 static LOGGER: SimpleLogger = SimpleLogger;
 
 /// Initializes a simple stdout logger for purecv log messages.
@@ -215,6 +223,10 @@ static LOGGER: SimpleLogger = SimpleLogger;
 ///
 /// This is helpful for CLI tools or examples to quickly view logs without
 /// pulling in external dependencies like `env_logger`.
+///
+/// Requires the `std` feature (it writes to stdout). Under `no_std`, install
+/// your own [`log`] backend instead.
+#[cfg(feature = "std")]
 pub fn init_basic_logger() -> Result<(), crate::core::PureCvError> {
     log::set_logger(&LOGGER).map_err(|e| {
         crate::core::PureCvError::InvalidInput(format!("Logger already set: {}", e))

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -186,6 +186,44 @@ pub fn get_log_level() -> LogLevel {
     LogLevel::from(log::max_level())
 }
 
+struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            println!(
+                "[{}] {} - {}",
+                record.level(),
+                record.target(),
+                record.args()
+            );
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: SimpleLogger = SimpleLogger;
+
+/// Initializes a simple stdout logger for purecv log messages.
+///
+/// Returns an error if a logger has already been set.
+///
+/// This is helpful for CLI tools or examples to quickly view logs without
+/// pulling in external dependencies like `env_logger`.
+pub fn init_basic_logger() -> Result<(), crate::core::PureCvError> {
+    log::set_logger(&LOGGER)
+        .map_err(|e| crate::core::PureCvError::InvalidInput(format!("Logger already set: {}", e)))?;
+    if log::max_level() == log::LevelFilter::Off {
+        log::set_max_level(log::LevelFilter::Info);
+    }
+    Ok(())
+}
+
 // ── Subsystem tags ─────────────────────────────────────────────────
 
 /// Per-subsystem tag constants for use with `cv_log_*!` macros.

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -216,8 +216,9 @@ static LOGGER: SimpleLogger = SimpleLogger;
 /// This is helpful for CLI tools or examples to quickly view logs without
 /// pulling in external dependencies like `env_logger`.
 pub fn init_basic_logger() -> Result<(), crate::core::PureCvError> {
-    log::set_logger(&LOGGER)
-        .map_err(|e| crate::core::PureCvError::InvalidInput(format!("Logger already set: {}", e)))?;
+    log::set_logger(&LOGGER).map_err(|e| {
+        crate::core::PureCvError::InvalidInput(format!("Logger already set: {}", e))
+    })?;
     if log::max_level() == log::LevelFilter::Off {
         log::set_max_level(log::LevelFilter::Info);
     }

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -1,0 +1,396 @@
+/*
+ *  logging.rs
+ *  purecv
+ *
+ *  This file is part of purecv - WebARKit.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! OpenCV-compatible structured logging API.
+//!
+//! This module mirrors [`cv::utils::logging`](https://docs.opencv.org/4.x/d5/d14/namespacecv_1_1utils_1_1logging.html)
+//! and is built on top of the [`log`](https://crates.io/crates/log) facade so
+//! the output backend stays the application's choice (e.g. `env_logger`, `fern`,
+//! `tracing`, `console_log` on WASM).
+//!
+//! # Level Mapping
+//!
+//! | [`LogLevel`]   | [`log::Level`]     | Notes                          |
+//! |----------------|--------------------|--------------------------------|
+//! | `Silent`       | *(off)*            | Disables all logging           |
+//! | `Fatal`        | `Error`            | Collapsed onto `Error`         |
+//! | `Error`        | `Error`            |                                |
+//! | `Warning`      | `Warn`             |                                |
+//! | `Info`         | `Info`             |                                |
+//! | `Debug`        | `Debug`            |                                |
+//! | `Verbose`      | `Trace`            | Collapsed onto `Trace`         |
+//!
+//! # Compile-time stripping
+//!
+//! The `log` crate provides cargo features `max_level_*` and
+//! `release_max_level_*` that strip log calls at compile time, equivalent to
+//! OpenCV's `CV_LOG_STRIP_LEVEL`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use purecv::core::logging::{self, tags, LogLevel};
+//!
+//! let prev = logging::set_log_level(LogLevel::Info);
+//! purecv::cv_log_info!(tags::IMGPROC, "gaussian blur, ksize = {}", 5);
+//! ```
+
+use core::fmt;
+
+// ── LogLevel enum ──────────────────────────────────────────────────
+
+/// Log severity levels mirroring OpenCV's `cv::utils::logging::LogLevel`.
+///
+/// The ordering matches OpenCV: `Silent` is the most restrictive (no output)
+/// and `Verbose` is the most permissive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogLevel {
+    /// Suppress all log output.
+    Silent = 0,
+    /// Fatal error — maps to [`log::Level::Error`].
+    Fatal = 1,
+    /// Error — maps to [`log::Level::Error`].
+    Error = 2,
+    /// Warning — maps to [`log::Level::Warn`].
+    Warning = 3,
+    /// Informational — maps to [`log::Level::Info`].
+    Info = 4,
+    /// Debug — maps to [`log::Level::Debug`].
+    Debug = 5,
+    /// Verbose / trace — maps to [`log::Level::Trace`].
+    Verbose = 6,
+}
+
+impl PartialOrd for LogLevel {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for LogLevel {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        (*self as u8).cmp(&(*other as u8))
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LogLevel::Silent => write!(f, "SILENT"),
+            LogLevel::Fatal => write!(f, "FATAL"),
+            LogLevel::Error => write!(f, "ERROR"),
+            LogLevel::Warning => write!(f, "WARNING"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Debug => write!(f, "DEBUG"),
+            LogLevel::Verbose => write!(f, "VERBOSE"),
+        }
+    }
+}
+
+impl From<LogLevel> for log::LevelFilter {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Silent => log::LevelFilter::Off,
+            LogLevel::Fatal | LogLevel::Error => log::LevelFilter::Error,
+            LogLevel::Warning => log::LevelFilter::Warn,
+            LogLevel::Info => log::LevelFilter::Info,
+            LogLevel::Debug => log::LevelFilter::Debug,
+            LogLevel::Verbose => log::LevelFilter::Trace,
+        }
+    }
+}
+
+impl From<log::LevelFilter> for LogLevel {
+    fn from(filter: log::LevelFilter) -> Self {
+        match filter {
+            log::LevelFilter::Off => LogLevel::Silent,
+            log::LevelFilter::Error => LogLevel::Error,
+            log::LevelFilter::Warn => LogLevel::Warning,
+            log::LevelFilter::Info => LogLevel::Info,
+            log::LevelFilter::Debug => LogLevel::Debug,
+            log::LevelFilter::Trace => LogLevel::Verbose,
+        }
+    }
+}
+
+impl From<log::Level> for LogLevel {
+    fn from(level: log::Level) -> Self {
+        match level {
+            log::Level::Error => LogLevel::Error,
+            log::Level::Warn => LogLevel::Warning,
+            log::Level::Info => LogLevel::Info,
+            log::Level::Debug => LogLevel::Debug,
+            log::Level::Trace => LogLevel::Verbose,
+        }
+    }
+}
+
+// ── set / get ──────────────────────────────────────────────────────
+
+/// Sets the global log level and returns the previous level.
+///
+/// This is the Rust equivalent of OpenCV's `cv::utils::logging::setLogLevel`.
+///
+/// # Example
+///
+/// ```rust
+/// use purecv::core::logging::{set_log_level, get_log_level, LogLevel};
+///
+/// let prev = set_log_level(LogLevel::Debug);
+/// assert_eq!(get_log_level(), LogLevel::Debug);
+/// set_log_level(prev); // restore
+/// ```
+pub fn set_log_level(level: LogLevel) -> LogLevel {
+    let previous = get_log_level();
+    log::set_max_level(log::LevelFilter::from(level));
+    previous
+}
+
+/// Returns the current global log level.
+///
+/// This is the Rust equivalent of OpenCV's `cv::utils::logging::getLogLevel`.
+pub fn get_log_level() -> LogLevel {
+    LogLevel::from(log::max_level())
+}
+
+// ── Subsystem tags ─────────────────────────────────────────────────
+
+/// Per-subsystem tag constants for use with `cv_log_*!` macros.
+///
+/// These map onto the `log` crate's `target:` field, enabling per-module
+/// filtering via standard tooling, e.g.:
+///
+/// ```text
+/// RUST_LOG=purecv::imgproc=debug,purecv::core=warn
+/// ```
+pub mod tags {
+    /// Root tag for the purecv crate.
+    pub const PURECV: &str = "purecv";
+    /// Tag for `purecv::core` subsystem.
+    pub const CORE: &str = "purecv::core";
+    /// Tag for `purecv::imgproc` subsystem.
+    pub const IMGPROC: &str = "purecv::imgproc";
+    /// Tag for `purecv::features2d` subsystem.
+    pub const FEATURES2D: &str = "purecv::features2d";
+    /// Tag for `purecv::calib3d` subsystem.
+    pub const CALIB3D: &str = "purecv::calib3d";
+    /// Tag for `purecv::video` subsystem.
+    pub const VIDEO: &str = "purecv::video";
+}
+
+// ── Level macros ───────────────────────────────────────────────────
+
+/// Log at **fatal** level (mapped to `log::error!`).
+///
+/// OpenCV equivalent: `CV_LOG_FATAL(tag, ...)`.
+///
+/// # Example
+///
+/// ```rust
+/// use purecv::core::logging::tags;
+/// purecv::cv_log_fatal!(tags::CORE, "unrecoverable: {}", "out of memory");
+/// ```
+#[macro_export]
+macro_rules! cv_log_fatal {
+    ($tag:expr, $($arg:tt)+) => {
+        log::error!(target: $tag, $($arg)+)
+    };
+}
+
+/// Log at **error** level.
+///
+/// OpenCV equivalent: `CV_LOG_ERROR(tag, ...)`.
+#[macro_export]
+macro_rules! cv_log_error {
+    ($tag:expr, $($arg:tt)+) => {
+        log::error!(target: $tag, $($arg)+)
+    };
+}
+
+/// Log at **warning** level.
+///
+/// OpenCV equivalent: `CV_LOG_WARNING(tag, ...)`.
+#[macro_export]
+macro_rules! cv_log_warning {
+    ($tag:expr, $($arg:tt)+) => {
+        log::warn!(target: $tag, $($arg)+)
+    };
+}
+
+/// Log at **info** level.
+///
+/// OpenCV equivalent: `CV_LOG_INFO(tag, ...)`.
+#[macro_export]
+macro_rules! cv_log_info {
+    ($tag:expr, $($arg:tt)+) => {
+        log::info!(target: $tag, $($arg)+)
+    };
+}
+
+/// Log at **debug** level.
+///
+/// OpenCV equivalent: `CV_LOG_DEBUG(tag, ...)`.
+#[macro_export]
+macro_rules! cv_log_debug {
+    ($tag:expr, $($arg:tt)+) => {
+        log::debug!(target: $tag, $($arg)+)
+    };
+}
+
+/// Log at **verbose** (trace) level.
+///
+/// OpenCV equivalent: `CV_LOG_VERBOSE(tag, v, ...)`.
+///
+/// The `v` parameter is the verbosity sub-level. Since the `log` crate does
+/// not support sub-levels, `v` is accepted for API parity but not enforced.
+/// All verbose messages map to [`log::trace!`].
+#[macro_export]
+macro_rules! cv_log_verbose {
+    ($tag:expr, $v:expr, $($arg:tt)+) => {
+        log::trace!(target: $tag, $($arg)+)
+    };
+}
+
+// ── Once-per-call-site macros ──────────────────────────────────────
+
+/// Log at **error** level, but only on the first invocation at each call site.
+///
+/// Uses a `core::sync::atomic::AtomicBool` per call site to track whether the
+/// message has already been emitted. This is `no_std`-friendly.
+#[macro_export]
+macro_rules! cv_log_once_error {
+    ($tag:expr, $($arg:tt)+) => {{
+        static LOGGED: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
+        if !LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+            log::error!(target: $tag, $($arg)+);
+        }
+    }};
+}
+
+/// Log at **warning** level, but only on the first invocation at each call site.
+#[macro_export]
+macro_rules! cv_log_once_warning {
+    ($tag:expr, $($arg:tt)+) => {{
+        static LOGGED: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
+        if !LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+            log::warn!(target: $tag, $($arg)+);
+        }
+    }};
+}
+
+/// Log at **info** level, but only on the first invocation at each call site.
+#[macro_export]
+macro_rules! cv_log_once_info {
+    ($tag:expr, $($arg:tt)+) => {{
+        static LOGGED: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
+        if !LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+            log::info!(target: $tag, $($arg)+);
+        }
+    }};
+}
+
+/// Log at **debug** level, but only on the first invocation at each call site.
+#[macro_export]
+macro_rules! cv_log_once_debug {
+    ($tag:expr, $($arg:tt)+) => {{
+        static LOGGED: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
+        if !LOGGED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+            log::debug!(target: $tag, $($arg)+);
+        }
+    }};
+}
+
+// ── Conditional macros ─────────────────────────────────────────────
+
+/// Log at **error** level if `condition` is true.
+///
+/// OpenCV equivalent: `CV_LOG_IF_ERROR(tag, condition, ...)`.
+///
+/// # Example
+///
+/// ```rust
+/// use purecv::core::logging::tags;
+/// let ksize = 4;
+/// purecv::cv_log_if_error!(tags::CORE, ksize % 2 == 0, "even kernel size: {}", ksize);
+/// ```
+#[macro_export]
+macro_rules! cv_log_if_error {
+    ($tag:expr, $cond:expr, $($arg:tt)+) => {
+        if $cond {
+            log::error!(target: $tag, $($arg)+);
+        }
+    };
+}
+
+/// Log at **warning** level if `condition` is true.
+///
+/// OpenCV equivalent: `CV_LOG_IF_WARNING(tag, condition, ...)`.
+#[macro_export]
+macro_rules! cv_log_if_warning {
+    ($tag:expr, $cond:expr, $($arg:tt)+) => {
+        if $cond {
+            log::warn!(target: $tag, $($arg)+);
+        }
+    };
+}
+
+/// Log at **info** level if `condition` is true.
+///
+/// OpenCV equivalent: `CV_LOG_IF_INFO(tag, condition, ...)`.
+#[macro_export]
+macro_rules! cv_log_if_info {
+    ($tag:expr, $cond:expr, $($arg:tt)+) => {
+        if $cond {
+            log::info!(target: $tag, $($arg)+);
+        }
+    };
+}
+
+/// Log at **debug** level if `condition` is true.
+///
+/// OpenCV equivalent: `CV_LOG_IF_DEBUG(tag, condition, ...)`.
+#[macro_export]
+macro_rules! cv_log_if_debug {
+    ($tag:expr, $cond:expr, $($arg:tt)+) => {
+        if $cond {
+            log::debug!(target: $tag, $($arg)+);
+        }
+    };
+}

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -33,8 +33,10 @@
  *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
  *
  */
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::types::Scalar;
+use crate::{cv_bail, cv_err};
 
 /// Matrix depth: number of bits per element and its signedness/type.
 /// Follows OpenCV's depth conventions (CV_8U, CV_32F, etc.).
@@ -338,11 +340,13 @@ impl<T: Default + Clone> Matrix<T> {
         T: Default + Clone + DataType,
     {
         if mat_type.depth() != T::depth() {
-            return Err(PureCvError::InvalidInput(format!(
-                "MatType depth {:?} does not match element type {:?}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_with_type: MatType depth {:?} does not match element type {:?}",
                 mat_type.depth(),
                 T::depth()
-            )));
+            );
         }
         Ok(Self::new(rows, cols, mat_type.channels()))
     }
@@ -384,11 +388,13 @@ impl<T: Default + Clone> Matrix<T> {
         T: Default + Clone + DataType,
     {
         if mat_type.depth() != T::depth() {
-            return Err(PureCvError::InvalidInput(format!(
-                "MatType depth {:?} does not match element type {:?}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "create_with_type: MatType depth {:?} does not match element type {:?}",
                 mat_type.depth(),
                 T::depth()
-            )));
+            );
         }
         self.create(rows, cols, mat_type.channels());
         Ok(())
@@ -479,7 +485,7 @@ impl<T: Default + Clone> Matrix<T> {
     /// Channels beyond 4 are set to `T::default()` (zero).
     ///
     /// # Errors
-    /// Returns [`PureCvError::InvalidDimensions`] if `mask` does not have the
+    /// Returns [`crate::core::error::PureCvError::InvalidDimensions`] if `mask` does not have the
     /// same number of rows and columns as `self`.
     ///
     /// # Example
@@ -494,10 +500,15 @@ impl<T: Default + Clone> Matrix<T> {
     /// ```
     pub fn set_to_masked(&mut self, s: Scalar<T>, mask: &Matrix<u8>) -> Result<()> {
         if self.rows != mask.rows || self.cols != mask.cols {
-            return Err(PureCvError::InvalidDimensions(format!(
-                "mask {}×{} does not match matrix {}×{}",
-                mask.rows, mask.cols, self.rows, self.cols
-            )));
+            cv_bail!(
+                tags::CORE,
+                InvalidDimensions,
+                "set_to_masked: mask {}×{} does not match matrix {}×{}",
+                mask.rows,
+                mask.cols,
+                self.rows,
+                self.cols
+            );
         }
         for row in 0..self.rows {
             for col in 0..self.cols {
@@ -524,7 +535,13 @@ impl<T: Default + Clone> Matrix<T> {
             .data
             .iter()
             .map(|&x| {
-                U::from(x).ok_or_else(|| PureCvError::InvalidInput("Conversion failed".into()))
+                U::from(x).ok_or_else(|| {
+                    cv_err!(
+                        tags::CORE,
+                        InvalidInput,
+                        "convert_to: element conversion failed"
+                    )
+                })
             })
             .collect::<Result<Vec<U>>>()?;
 
@@ -644,11 +661,13 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
         T: DataType,
     {
         if mat_type.depth() != T::depth() {
-            return Err(PureCvError::InvalidInput(format!(
-                "MatType depth {:?} does not match element type {:?}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "zeros_with_type: MatType depth {:?} does not match element type {:?}",
                 mat_type.depth(),
                 T::depth()
-            )));
+            );
         }
         Ok(Self::zeros(rows, cols, mat_type.channels()))
     }
@@ -659,11 +678,13 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
         T: DataType,
     {
         if mat_type.depth() != T::depth() {
-            return Err(PureCvError::InvalidInput(format!(
-                "MatType depth {:?} does not match element type {:?}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "ones_with_type: MatType depth {:?} does not match element type {:?}",
                 mat_type.depth(),
                 T::depth()
-            )));
+            );
         }
         Ok(Self::ones(rows, cols, mat_type.channels()))
     }
@@ -705,7 +726,7 @@ impl<T: Default + Clone + DataType> Matrix<T> {
     /// mismatches are caught at runtime rather than producing silent garbage.
     ///
     /// # Errors
-    /// Returns [`PureCvError::InvalidInput`] when `mat_type.depth() != T::depth()`.
+    /// Returns [`crate::core::error::PureCvError::InvalidInput`] when `mat_type.depth() != T::depth()`.
     ///
     /// # Example
     /// ```
@@ -725,11 +746,13 @@ impl<T: Default + Clone + DataType> Matrix<T> {
         s: Scalar<T>,
     ) -> Result<Self> {
         if mat_type.depth() != T::depth() {
-            return Err(PureCvError::InvalidInput(format!(
-                "MatType depth {:?} does not match element type depth {:?}",
+            cv_bail!(
+                tags::CORE,
+                InvalidInput,
+                "new_with_scalar_typed_from_size: MatType depth {:?} does not match element type depth {:?}",
                 mat_type.depth(),
                 T::depth()
-            )));
+            );
         }
         let rows = size.height.into();
         let cols = size.width.into();

--- a/src/core/matrix.rs
+++ b/src/core/matrix.rs
@@ -33,8 +33,10 @@
  *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
  *
  */
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::Scalar;
+use alloc::{format, vec, vec::Vec};
 
 /// Matrix depth: number of bits per element and its signedness/type.
 /// Follows OpenCV's depth conventions (CV_8U, CV_32F, etc.).
@@ -545,7 +547,7 @@ impl<T: Default + Clone> Matrix<T> {
     ///
     /// * `other` - The matrix with which to swap references logic correctly.
     pub fn swap(&mut self, other: &mut Self) {
-        std::mem::swap(self, other);
+        core::mem::swap(self, other);
     }
 
     /// Returns a raw immutable pointer to the start of the underlying data
@@ -592,9 +594,14 @@ impl<T: Default + Clone> Matrix<T> {
     pub fn copy_to(&self, dst: &mut Matrix<T>) -> Result<()> {
         if self.rows != dst.rows || self.cols != dst.cols || self.channels != dst.channels {
             #[cfg(debug_assertions)]
-            eprintln!(
+            log::warn!(
                 "[purecv::copy_to] dst resized from {}x{}x{} to {}x{}x{}",
-                dst.rows, dst.cols, dst.channels, self.rows, self.cols, self.channels
+                dst.rows,
+                dst.cols,
+                dst.channels,
+                self.rows,
+                self.cols,
+                self.channels
             );
             dst.rows = self.rows;
             dst.cols = self.cols;
@@ -672,7 +679,7 @@ impl<T: num_traits::Zero + num_traits::One + Default + Clone> Matrix<T> {
     /// Following OpenCV, the diagonal has value 1 and others are 0.
     pub fn eye(rows: usize, cols: usize, channels: usize) -> Self {
         let mut mat = Self::zeros(rows, cols, channels);
-        let min_dim = std::cmp::min(rows, cols);
+        let min_dim = core::cmp::min(rows, cols);
         for i in 0..min_dim {
             for c in 0..channels {
                 mat.set(i, i, c, T::one());

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -34,8 +34,10 @@
  *
  */
 
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::matrix::Matrix;
+use crate::cv_bail;
 
 /// Computes the Peak Signal-to-Noise Ratio (PSNR) between two matrices.
 ///
@@ -64,9 +66,17 @@ where
     T: Copy + Into<f64>,
 {
     if img1.rows != img2.rows || img1.cols != img2.cols || img1.channels != img2.channels {
-        return Err(PureCvError::InvalidDimensions(
-            "Images must have same dimensions for PSNR".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "psnr: images must have the same dimensions (img1 {}×{}×{}, img2 {}×{}×{})",
+            img1.rows,
+            img1.cols,
+            img1.channels,
+            img2.rows,
+            img2.cols,
+            img2.channels
+        );
     }
 
     let mut mse = 0.0;
@@ -113,16 +123,29 @@ where
 {
     // Ensure vectors are column vectors of the same size.
     if src1.rows != src2.rows || src1.cols != 1 || src2.cols != 1 {
-        return Err(PureCvError::InvalidDimensions(
-            "src1 and src2 must be column vectors of the same size".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "mahalanobis: src1 and src2 must be column vectors of the same size \
+             (src1 {}×{}, src2 {}×{})",
+            src1.rows,
+            src1.cols,
+            src2.rows,
+            src2.cols
+        );
     }
 
     // Ensure covariance matrix is square and matches vector size
     if covar_inv.rows != covar_inv.cols || covar_inv.rows != src1.rows {
-        return Err(PureCvError::InvalidDimensions(
-            "covar_inv must be a square matrix matching vector size".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "mahalanobis: covar_inv must be a square matrix matching vector size \
+             (covar_inv {}×{}, vector size {})",
+            covar_inv.rows,
+            covar_inv.cols,
+            src1.rows
+        );
     }
 
     let n = src1.rows;

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -34,6 +34,13 @@
  *
  */
 
+// `num_traits::Float` provides `sqrt`, `sin`, ... on `f32`/`f64` via libm
+// when `std` is disabled; with `std` the inherent methods win, so the
+// import is only "used" in no_std builds.
+use alloc::vec;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::matrix::Matrix;
 

--- a/src/core/rng.rs
+++ b/src/core/rng.rs
@@ -35,9 +35,11 @@
  */
 
 use crate::core::constants::CV_2PI;
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::types::Scalar;
 use crate::core::Matrix;
+use crate::cv_bail;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::cell::RefCell;
 
@@ -177,9 +179,11 @@ where
     T: Default + Clone + FromPrimitive + ToPrimitive + Send + Sync,
 {
     if dst.data.is_empty() {
-        return Err(PureCvError::InvalidDimensions(
-            "destination matrix is empty".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "randu: destination matrix is empty"
+        );
     }
 
     let channels = dst.channels;
@@ -229,9 +233,11 @@ where
     T: Default + Clone + FromPrimitive + ToPrimitive + Send + Sync,
 {
     if dst.data.is_empty() {
-        return Err(PureCvError::InvalidDimensions(
-            "destination matrix is empty".into(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "randn: destination matrix is empty"
+        );
     }
 
     let channels = dst.channels;

--- a/src/core/rng.rs
+++ b/src/core/rng.rs
@@ -34,12 +34,22 @@
  *
  */
 
+// `num_traits::Float` provides `sqrt`, `sin`, ... on `f32`/`f64` via libm
+// when `std` is disabled; with `std` the inherent methods win, so the
+// import is only "used" in no_std builds.
 use crate::core::constants::CV_2PI;
+#[cfg(feature = "std")]
 use crate::core::error::{PureCvError, Result};
+#[cfg(feature = "std")]
 use crate::core::types::Scalar;
+#[cfg(feature = "std")]
 use crate::core::Matrix;
+#[cfg(feature = "std")]
+use core::cell::RefCell;
+#[allow(unused_imports)]
+use num_traits::Float;
+#[cfg(feature = "std")]
 use num_traits::{FromPrimitive, ToPrimitive};
-use std::cell::RefCell;
 
 // ---------------------------------------------------------------------------
 // Xoshiro256** — a fast, high-quality pure-Rust PRNG (public domain algorithm
@@ -47,11 +57,16 @@ use std::cell::RefCell;
 // ---------------------------------------------------------------------------
 
 /// Internal state for the xoshiro256** generator.
+// Without `std` the thread-local RNG below is compiled out, leaving this
+// generator temporarily unused; a seedable no_std API is planned in #82.
+#[cfg_attr(not(feature = "std"), allow(dead_code))]
 #[derive(Clone)]
 struct Xoshiro256 {
     s: [u64; 4],
 }
 
+// See the note on `Xoshiro256`: without `std` these methods have no caller yet.
+#[cfg_attr(not(feature = "std"), allow(dead_code))]
 impl Xoshiro256 {
     /// Creates a new generator seeded by expanding `seed` through SplitMix64.
     fn from_seed(seed: u64) -> Self {
@@ -122,7 +137,8 @@ impl Xoshiro256 {
 // Thread-local RNG state
 // ---------------------------------------------------------------------------
 
-thread_local! {
+#[cfg(feature = "std")]
+std::thread_local! {
     static THREAD_RNG: RefCell<Xoshiro256> = RefCell::new(Xoshiro256::from_seed(0));
 }
 
@@ -140,6 +156,7 @@ thread_local! {
 /// use purecv::core::set_rng_seed;
 /// set_rng_seed(42);
 /// ```
+#[cfg(feature = "std")]
 pub fn set_rng_seed(seed: u64) {
     THREAD_RNG.with(|rng| {
         *rng.borrow_mut() = Xoshiro256::from_seed(seed);
@@ -172,6 +189,7 @@ pub fn set_rng_seed(seed: u64) {
 /// let mut mat = Matrix::<f32>::new(100, 100, 1);
 /// randu(&mut mat, Scalar::all(0.0), Scalar::all(1.0)).unwrap();
 /// ```
+#[cfg(feature = "std")]
 pub fn randu<T>(dst: &mut Matrix<T>, low: Scalar<f64>, high: Scalar<f64>) -> Result<()>
 where
     T: Default + Clone + FromPrimitive + ToPrimitive + Send + Sync,
@@ -224,6 +242,7 @@ where
 /// let mut mat = Matrix::<f64>::new(100, 100, 1);
 /// randn(&mut mat, Scalar::all(0.0), Scalar::all(1.0)).unwrap();
 /// ```
+#[cfg(feature = "std")]
 pub fn randn<T>(dst: &mut Matrix<T>, mean: Scalar<f64>, std_dev: Scalar<f64>) -> Result<()>
 where
     T: Default + Clone + FromPrimitive + ToPrimitive + Send + Sync,
@@ -267,6 +286,7 @@ where
 ///
 /// # Arguments
 /// * `slice` - The slice to shuffle.
+#[cfg(feature = "std")]
 pub fn rand_shuffle<T>(slice: &mut [T]) {
     if slice.is_empty() {
         return;

--- a/src/core/solvers.rs
+++ b/src/core/solvers.rs
@@ -34,6 +34,13 @@
  *
  */
 
+// `num_traits::Float` provides `sqrt`, `sin`, ... on `f32`/`f64` via libm
+// when `std` is disabled; with `std` the inherent methods win, so the
+// import is only "used" in no_std builds.
+use alloc::{vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::constants::CV_PI;
 use crate::core::error::Result;
 

--- a/src/core/structural.rs
+++ b/src/core/structural.rs
@@ -34,9 +34,11 @@
  *
  */
 
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
 use crate::core::types::Scalar;
 use crate::core::Matrix;
+use crate::{cv_bail, cv_err};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -219,9 +221,11 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if src.is_empty() || dst.is_empty() || from_to.is_empty() {
-        return Err(PureCvError::InvalidInput(
-            "Input/Output/from_to cannot be empty".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "mix_channels: input/output/from_to cannot be empty"
+        );
     }
 
     let rows = src[0].rows;
@@ -230,16 +234,20 @@ where
     // Validate dimensions
     for m in src {
         if m.rows != rows || m.cols != cols {
-            return Err(PureCvError::InvalidDimensions(
-                "All source matrices must have the same size".to_string(),
-            ));
+            cv_bail!(
+                tags::CORE,
+                InvalidDimensions,
+                "mix_channels: all source matrices must have the same size"
+            );
         }
     }
     for m in dst.iter() {
         if m.rows != rows || m.cols != cols {
-            return Err(PureCvError::InvalidDimensions(
-                "All destination matrices must have the same size".to_string(),
-            ));
+            cv_bail!(
+                tags::CORE,
+                InvalidDimensions,
+                "mix_channels: all destination matrices must have the same size"
+            );
         }
     }
 
@@ -431,9 +439,11 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if mv.is_empty() {
-        return Err(PureCvError::InvalidDimensions(
-            "Input vector is empty".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "merge: input vector is empty"
+        );
     }
 
     let rows = mv[0].rows;
@@ -442,9 +452,11 @@ where
 
     for m in mv {
         if m.rows != rows || m.cols != cols || m.channels != 1 {
-            return Err(PureCvError::InvalidDimensions(
-                "All matrices must have the same size and 1 channel".to_string(),
-            ));
+            cv_bail!(
+                tags::CORE,
+                InvalidDimensions,
+                "merge: all matrices must have the same size and 1 channel"
+            );
         }
     }
 
@@ -499,8 +511,11 @@ where
             let t = transpose(src)?;
             flip(&t, 0)
         }
-        _ => Err(PureCvError::InvalidDimensions(
-            "Invalid rotate_code. Must be 0, 1, or 2".to_string(),
+        _ => Err(cv_err!(
+            tags::CORE,
+            InvalidDimensions,
+            "rotate: invalid rotate_code {}, must be 0, 1, or 2",
+            rotate_code
         )),
     }
 }
@@ -511,9 +526,13 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if ny == 0 || nx == 0 {
-        return Err(PureCvError::InvalidDimensions(
-            "ny and nx must be > 0".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "repeat: ny and nx must be > 0 (got ny = {}, nx = {})",
+            ny,
+            nx
+        );
     }
 
     let mut dst = Matrix::<T>::new(src.rows * ny, src.cols * nx, src.channels);
@@ -570,20 +589,26 @@ where
     };
 
     if !total_elements.is_multiple_of(actual_new_channels) {
-        return Err(PureCvError::InvalidDimensions(format!(
-            "Total elements ({}) is not divisible by new_channels ({})",
-            total_elements, actual_new_channels
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "reshape: total elements ({}) is not divisible by new_channels ({})",
+            total_elements,
+            actual_new_channels
+        );
     }
 
     let total_pixels = total_elements / actual_new_channels;
     let actual_new_rows = if new_rows == 0 { src.rows } else { new_rows };
 
     if !total_pixels.is_multiple_of(actual_new_rows) {
-        return Err(PureCvError::InvalidDimensions(format!(
-            "Total pixels ({}) is not divisible by new_rows ({})",
-            total_pixels, actual_new_rows
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "reshape: total pixels ({}) is not divisible by new_rows ({})",
+            total_pixels,
+            actual_new_rows
+        );
     }
 
     let new_cols = total_pixels / actual_new_rows;
@@ -600,9 +625,7 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if src.is_empty() {
-        return Err(PureCvError::InvalidInput(
-            "Input array is empty".to_string(),
-        ));
+        cv_bail!(tags::CORE, InvalidInput, "hconcat: input array is empty");
     }
 
     let rows = src[0].rows;
@@ -611,9 +634,11 @@ where
 
     for m in src {
         if m.rows != rows || m.channels != channels {
-            return Err(PureCvError::InvalidDimensions(
-                "All matrices must have the same number of rows and channels".to_string(),
-            ));
+            cv_bail!(
+                tags::CORE,
+                InvalidDimensions,
+                "hconcat: all matrices must have the same number of rows and channels"
+            );
         }
         total_cols += m.cols;
     }
@@ -661,9 +686,7 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if src.is_empty() {
-        return Err(PureCvError::InvalidInput(
-            "Input array is empty".to_string(),
-        ));
+        cv_bail!(tags::CORE, InvalidInput, "vconcat: input array is empty");
     }
 
     let cols = src[0].cols;
@@ -672,9 +695,11 @@ where
 
     for m in src {
         if m.cols != cols || m.channels != channels {
-            return Err(PureCvError::InvalidDimensions(
-                "All matrices must have the same number of columns and channels".to_string(),
-            ));
+            cv_bail!(
+                tags::CORE,
+                InvalidDimensions,
+                "vconcat: all matrices must have the same number of columns and channels"
+            );
         }
         total_rows += m.rows;
     }
@@ -696,10 +721,13 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if coi >= src.channels {
-        return Err(PureCvError::InvalidInput(format!(
-            "Channel index {} is out of range (total channels: {})",
-            coi, src.channels
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "extract_channel: channel index {} is out of range (total channels: {})",
+            coi,
+            src.channels
+        );
     }
 
     let mut dst = Matrix::<T>::new(src.rows, src.cols, 1);
@@ -728,16 +756,21 @@ where
     T: Copy + Send + Sync + Default + 'static,
 {
     if coi >= dst.channels {
-        return Err(PureCvError::InvalidInput(format!(
-            "Channel index {} is out of range (destination channels: {})",
-            coi, dst.channels
-        )));
+        cv_bail!(
+            tags::CORE,
+            InvalidInput,
+            "insert_channel: channel index {} is out of range (destination channels: {})",
+            coi,
+            dst.channels
+        );
     }
 
     if src.rows != dst.rows || src.cols != dst.cols || src.channels != 1 {
-        return Err(PureCvError::InvalidDimensions(
-            "Source must be single-channel and match destination size".to_string(),
-        ));
+        cv_bail!(
+            tags::CORE,
+            InvalidDimensions,
+            "insert_channel: source must be single-channel and match destination size"
+        );
     }
 
     let channels = dst.channels;

--- a/src/core/structural.rs
+++ b/src/core/structural.rs
@@ -34,6 +34,8 @@
  *
  */
 
+use alloc::{format, string::ToString, vec::Vec};
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::Scalar;
 use crate::core::Matrix;

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1698,6 +1698,59 @@ mod core_tests {
     }
 
     #[test]
+    fn test_cv_bail_logs_and_returns_error() {
+        use crate::core::error::{PureCvError, Result};
+
+        fn check(a: usize, b: usize) -> Result<()> {
+            if a != b {
+                crate::cv_bail!(tags::CORE, InvalidDimensions, "mismatch: {} != {}", a, b);
+            }
+            Ok(())
+        }
+
+        // Failing path returns the expected variant with the formatted message.
+        match check(1, 2) {
+            Err(PureCvError::InvalidDimensions(msg)) => assert_eq!(msg, "mismatch: 1 != 2"),
+            other => panic!("expected InvalidDimensions, got {other:?}"),
+        }
+        // Passing path returns Ok.
+        assert!(check(3, 3).is_ok());
+    }
+
+    #[test]
+    fn test_cv_err_yields_error_value() {
+        use crate::core::error::PureCvError;
+
+        fn make(kind: u8) -> PureCvError {
+            match kind {
+                0 => crate::cv_err!(tags::CORE, InvalidInput, "bad input {}", kind),
+                _ => crate::cv_err!(tags::CORE, NotImplemented, "todo"),
+            }
+        }
+
+        assert_eq!(
+            make(0),
+            PureCvError::InvalidInput("bad input 0".to_string())
+        );
+        assert_eq!(make(9), PureCvError::NotImplemented("todo".to_string()));
+    }
+
+    #[test]
+    fn test_cv_bail_debug_and_cv_err_debug() {
+        use crate::core::error::{PureCvError, Result};
+
+        fn bail(x: i32) -> Result<()> {
+            crate::cv_bail_debug!(tags::CORE, NotImplemented, "not yet: {}", x);
+        }
+        fn err() -> PureCvError {
+            crate::cv_err_debug!(tags::CORE, OutOfBounds, "oob")
+        }
+
+        assert!(matches!(bail(7), Err(PureCvError::NotImplemented(_))));
+        assert_eq!(err(), PureCvError::OutOfBounds("oob".to_string()));
+    }
+
+    #[test]
     fn test_tags_constants() {
         assert_eq!(tags::PURECV, "purecv");
         assert_eq!(tags::CORE, "purecv::core");

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1578,4 +1578,132 @@ mod core_tests {
         assert_eq!(src.get(0, 0, 0), Some(&10)); // src unchanged
         assert_eq!(dst.get(0, 0, 0), Some(&999));
     }
+
+    // ── Logging tests ──────────────────────────────────────────────────
+
+    use crate::core::logging::{self, tags, LogLevel};
+    use crate::{
+        cv_log_debug, cv_log_error, cv_log_fatal, cv_log_if_debug, cv_log_if_error, cv_log_if_info,
+        cv_log_if_warning, cv_log_info, cv_log_once_debug, cv_log_once_error, cv_log_once_info,
+        cv_log_once_warning, cv_log_verbose, cv_log_warning,
+    };
+
+    #[test]
+    fn test_log_level_ordering() {
+        assert!(LogLevel::Silent < LogLevel::Fatal);
+        assert!(LogLevel::Fatal < LogLevel::Error);
+        assert!(LogLevel::Error < LogLevel::Warning);
+        assert!(LogLevel::Warning < LogLevel::Info);
+        assert!(LogLevel::Info < LogLevel::Debug);
+        assert!(LogLevel::Debug < LogLevel::Verbose);
+    }
+
+    #[test]
+    fn test_log_level_to_level_filter_conversion() {
+        use log::LevelFilter;
+
+        assert_eq!(LevelFilter::from(LogLevel::Silent), LevelFilter::Off);
+        assert_eq!(LevelFilter::from(LogLevel::Fatal), LevelFilter::Error);
+        assert_eq!(LevelFilter::from(LogLevel::Error), LevelFilter::Error);
+        assert_eq!(LevelFilter::from(LogLevel::Warning), LevelFilter::Warn);
+        assert_eq!(LevelFilter::from(LogLevel::Info), LevelFilter::Info);
+        assert_eq!(LevelFilter::from(LogLevel::Debug), LevelFilter::Debug);
+        assert_eq!(LevelFilter::from(LogLevel::Verbose), LevelFilter::Trace);
+    }
+
+    #[test]
+    fn test_level_filter_to_log_level_conversion() {
+        use log::LevelFilter;
+
+        assert_eq!(LogLevel::from(LevelFilter::Off), LogLevel::Silent);
+        assert_eq!(LogLevel::from(LevelFilter::Error), LogLevel::Error);
+        assert_eq!(LogLevel::from(LevelFilter::Warn), LogLevel::Warning);
+        assert_eq!(LogLevel::from(LevelFilter::Info), LogLevel::Info);
+        assert_eq!(LogLevel::from(LevelFilter::Debug), LogLevel::Debug);
+        assert_eq!(LogLevel::from(LevelFilter::Trace), LogLevel::Verbose);
+    }
+
+    #[test]
+    fn test_log_level_display() {
+        assert_eq!(LogLevel::Silent.to_string(), "SILENT");
+        assert_eq!(LogLevel::Fatal.to_string(), "FATAL");
+        assert_eq!(LogLevel::Error.to_string(), "ERROR");
+        assert_eq!(LogLevel::Warning.to_string(), "WARNING");
+        assert_eq!(LogLevel::Info.to_string(), "INFO");
+        assert_eq!(LogLevel::Debug.to_string(), "DEBUG");
+        assert_eq!(LogLevel::Verbose.to_string(), "VERBOSE");
+    }
+
+    #[test]
+    fn test_set_log_level_returns_previous() {
+        // Save the current level to restore later
+        let original = logging::get_log_level();
+
+        let prev = logging::set_log_level(LogLevel::Debug);
+        assert_eq!(prev, original);
+
+        let prev2 = logging::set_log_level(LogLevel::Warning);
+        assert_eq!(prev2, LogLevel::Debug);
+
+        // Restore
+        logging::set_log_level(original);
+    }
+
+    #[test]
+    fn test_log_level_round_trip() {
+        let original = logging::get_log_level();
+
+        logging::set_log_level(LogLevel::Info);
+        assert_eq!(logging::get_log_level(), LogLevel::Info);
+
+        logging::set_log_level(LogLevel::Verbose);
+        assert_eq!(logging::get_log_level(), LogLevel::Verbose);
+
+        logging::set_log_level(LogLevel::Silent);
+        assert_eq!(logging::get_log_level(), LogLevel::Silent);
+
+        // Restore
+        logging::set_log_level(original);
+    }
+
+    #[test]
+    fn test_cv_log_macros_compile() {
+        // Smoke test: verify all macros expand and execute without panic.
+        // No log backend is installed, so messages are silently dropped.
+        cv_log_fatal!(tags::CORE, "fatal test {}", 1);
+        cv_log_error!(tags::CORE, "error test {}", 2);
+        cv_log_warning!(tags::IMGPROC, "warning test {}", 3);
+        cv_log_info!(tags::PURECV, "info test {}", 4);
+        cv_log_debug!(tags::FEATURES2D, "debug test {}", 5);
+        cv_log_verbose!(tags::VIDEO, 0, "verbose test {}", 6);
+    }
+
+    #[test]
+    fn test_cv_log_once_macros_compile() {
+        // Once macros should compile and not panic
+        cv_log_once_error!(tags::CORE, "once error");
+        cv_log_once_warning!(tags::IMGPROC, "once warning {}", 42);
+        cv_log_once_info!(tags::PURECV, "once info");
+        cv_log_once_debug!(tags::CALIB3D, "once debug");
+    }
+
+    #[test]
+    fn test_cv_log_if_macros_compile() {
+        // Conditional macros with both true and false conditions
+        cv_log_if_error!(tags::CORE, true, "if error true");
+        cv_log_if_error!(tags::CORE, false, "if error false");
+        cv_log_if_warning!(tags::IMGPROC, 2 > 1, "if warning {}", "yes");
+        cv_log_if_info!(tags::PURECV, false, "should not log");
+        cv_log_if_debug!(tags::VIDEO, true, "if debug {}", 99);
+    }
+
+    #[test]
+    fn test_tags_constants() {
+        assert_eq!(tags::PURECV, "purecv");
+        assert_eq!(tags::CORE, "purecv::core");
+        assert_eq!(tags::IMGPROC, "purecv::imgproc");
+        assert_eq!(tags::FEATURES2D, "purecv::features2d");
+        assert_eq!(tags::CALIB3D, "purecv::calib3d");
+        assert_eq!(tags::VIDEO, "purecv::video");
+    }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -38,7 +38,9 @@ use std::ops::{Add, Div, Index, IndexMut, Mul, Sub};
 
 use num_traits::{CheckedDiv, Zero};
 
-use crate::core::error::{PureCvError, Result};
+use crate::core::error::Result;
+use crate::core::logging::tags;
+use crate::cv_err;
 
 pub type Uchar = u8;
 pub type Schar = i8;
@@ -402,7 +404,7 @@ impl<T: Copy + Default + CheckedDiv> Scalar<T> {
     /// `Div<Scalar<T>>` impl.
     ///
     /// # Errors
-    /// Returns [`PureCvError::InvalidInput`] naming the first channel whose
+    /// Returns [`crate::core::error::PureCvError::InvalidInput`] naming the first channel whose
     /// divisor is zero.
     ///
     /// # Example
@@ -418,7 +420,12 @@ impl<T: Copy + Default + CheckedDiv> Scalar<T> {
     pub fn checked_div(self, rhs: Scalar<T>) -> Result<Self> {
         let div_ch = |a: T, b: T, ch: usize| {
             a.checked_div(&b).ok_or_else(|| {
-                PureCvError::InvalidInput(format!("Division by zero in channel {ch}"))
+                cv_err!(
+                    tags::CORE,
+                    InvalidInput,
+                    "checked_div: division by zero in channel {}",
+                    ch
+                )
             })
         };
         Ok(Self {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -34,7 +34,9 @@
  *
  */
 
-use std::ops::{Add, Div, Index, IndexMut, Mul, Sub};
+use alloc::format;
+
+use core::ops::{Add, Div, Index, IndexMut, Mul, Sub};
 
 use num_traits::{CheckedDiv, Zero};
 
@@ -636,7 +638,7 @@ impl<T: Zero, const N: usize> VecN<T, N> {
     /// numeric types and guarantees that each element is the additive identity.
     pub fn zeros() -> Self {
         Self {
-            val: std::array::from_fn(|_| T::zero()),
+            val: core::array::from_fn(|_| T::zero()),
         }
     }
 }
@@ -645,7 +647,7 @@ impl<T: Copy, const N: usize> VecN<T, N> {
     /// Returns a vector with every element set to `v`.
     pub fn all(v: T) -> Self {
         Self {
-            val: std::array::from_fn(|_| v),
+            val: core::array::from_fn(|_| v),
         }
     }
 }
@@ -683,7 +685,7 @@ impl<T: Copy + Add<Output = T>, const N: usize> Add for VecN<T, N> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] + rhs.val[i]),
+            val: core::array::from_fn(|i| self.val[i] + rhs.val[i]),
         }
     }
 }
@@ -692,7 +694,7 @@ impl<T: Copy + Sub<Output = T>, const N: usize> Sub for VecN<T, N> {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] - rhs.val[i]),
+            val: core::array::from_fn(|i| self.val[i] - rhs.val[i]),
         }
     }
 }
@@ -705,7 +707,7 @@ impl<T: Copy + Default + Add<Output = T>, const N: usize> Add<Scalar<T>> for Vec
     type Output = Self;
     fn add(self, rhs: Scalar<T>) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] + rhs.channel_or_default(i)),
+            val: core::array::from_fn(|i| self.val[i] + rhs.channel_or_default(i)),
         }
     }
 }
@@ -716,7 +718,7 @@ impl<T: Copy + Default + Sub<Output = T>, const N: usize> Sub<Scalar<T>> for Vec
     type Output = Self;
     fn sub(self, rhs: Scalar<T>) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] - rhs.channel_or_default(i)),
+            val: core::array::from_fn(|i| self.val[i] - rhs.channel_or_default(i)),
         }
     }
 }
@@ -726,7 +728,7 @@ impl<T: Copy + Mul<Output = T>, const N: usize> Mul for VecN<T, N> {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] * rhs.val[i]),
+            val: core::array::from_fn(|i| self.val[i] * rhs.val[i]),
         }
     }
 }
@@ -736,7 +738,7 @@ impl<T: Copy + Mul<Output = T>, const N: usize> Mul<T> for VecN<T, N> {
     type Output = Self;
     fn mul(self, rhs: T) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] * rhs),
+            val: core::array::from_fn(|i| self.val[i] * rhs),
         }
     }
 }
@@ -746,7 +748,7 @@ impl<T: Copy + Div<Output = T>, const N: usize> Div<T> for VecN<T, N> {
     type Output = Self;
     fn div(self, rhs: T) -> Self {
         Self {
-            val: std::array::from_fn(|i| self.val[i] / rhs),
+            val: core::array::from_fn(|i| self.val[i] / rhs),
         }
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -76,16 +76,9 @@ impl Range {
     }
 }
 
-/// Sets the global log level.
-/// This is a wrapper around the `log` crate's level filter.
-pub fn set_log_level(level: log::LevelFilter) {
-    log::set_max_level(level);
-}
-
-/// Returns the current global log level.
-pub fn get_log_level() -> log::LevelFilter {
-    log::max_level()
-}
+// Log level functions have moved to `core::logging`.
+// Re-exported here for backwards-compatible import paths.
+pub use crate::core::logging::{get_log_level, set_log_level};
 
 /// Border interpolation helper.
 /// Returns the index of a pixel that would be at the given position `p`

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -34,19 +34,29 @@
  *
  */
 
+#[cfg(feature = "std")]
 use std::sync::OnceLock;
+#[cfg(feature = "std")]
 use std::time::Instant;
 
+#[cfg(feature = "std")]
 static START_TIME: OnceLock<Instant> = OnceLock::new();
 
 /// Returns the number of ticks.
 /// In this implementation, it returns the number of nanoseconds since the first call.
+///
+/// Requires the `std` feature: bare-metal targets have no portable clock,
+/// so embedded users should rely on their platform timer instead.
+#[cfg(feature = "std")]
 pub fn get_tick_count() -> i64 {
     let start = *START_TIME.get_or_init(Instant::now);
     start.elapsed().as_nanos() as i64
 }
 
 /// Returns the number of ticks per second.
+///
+/// Requires the `std` feature (see [`get_tick_count`]).
+#[cfg(feature = "std")]
 pub fn get_tick_frequency() -> f64 {
     1_000_000_000.0
 }
@@ -158,13 +168,13 @@ pub trait ParIterFallback<'a, T: 'a> {
 
     fn par_iter(&'a self) -> Self::Iter;
     fn par_iter_mut(&'a mut self) -> Self::IterMut;
-    fn par_chunks_mut(&'a mut self, size: usize) -> std::slice::ChunksMut<'a, T>;
+    fn par_chunks_mut(&'a mut self, size: usize) -> core::slice::ChunksMut<'a, T>;
 }
 
 #[cfg(not(feature = "parallel"))]
 impl<'a, T: 'a> ParIterFallback<'a, T> for [T] {
-    type Iter = std::slice::Iter<'a, T>;
-    type IterMut = std::slice::IterMut<'a, T>;
+    type Iter = core::slice::Iter<'a, T>;
+    type IterMut = core::slice::IterMut<'a, T>;
 
     fn par_iter(&'a self) -> Self::Iter {
         self.iter()
@@ -172,7 +182,7 @@ impl<'a, T: 'a> ParIterFallback<'a, T> for [T] {
     fn par_iter_mut(&'a mut self) -> Self::IterMut {
         self.iter_mut()
     }
-    fn par_chunks_mut(&'a mut self, size: usize) -> std::slice::ChunksMut<'a, T> {
+    fn par_chunks_mut(&'a mut self, size: usize) -> core::slice::ChunksMut<'a, T> {
         self.chunks_mut(size)
     }
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -34,6 +34,13 @@
  *
  */
 
+//! Feature detection and description — the `features` module.
+//!
+//! Placeholder for pure-Rust keypoint detectors and descriptors (e.g. FAST,
+//! ORB) mirroring OpenCV's feature-detection APIs. These are not yet
+//! implemented; the module is reserved so downstream code and documentation
+//! can reference a stable path as the algorithms land.
+
 //pub mod fast;
 //pub mod orb;
 

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -34,6 +34,23 @@
  *
  */
 
+//! Image processing — the `imgproc` module.
+//!
+//! This module mirrors OpenCV's `imgproc` module and implements common image
+//! processing algorithms in pure Rust, operating on the core [`Matrix`] type:
+//!
+//! - [`color`] — color-space conversions ([`cvt_color`] and friends).
+//! - [`filter`] — linear/nonlinear filtering (blur, Gaussian, Sobel, …).
+//! - [`derivatives`] and [`edge`] — image gradients and edge detection.
+//! - [`threshold`](mod@threshold) — fixed and adaptive thresholding.
+//! - [`morph`] — morphological operations (erode, dilate, `morphology_ex`).
+//! - [`geometric`] — geometric transforms ([`resize`](resize::resize),
+//!   [`warp_perspective`], `remap`).
+//! - [`pyramid`] — image pyramids (`pyr_down`, `pyr_up`).
+//! - [`hough`] and [`feature`] — shape/feature detection.
+//!
+//! [`Matrix`]: crate::core::Matrix
+
 pub mod color;
 pub mod derivatives;
 pub mod edge;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod prelude {
         find_fundamental_mat, find_homography, init_undistort_rectify_map, rodrigues, solve_pnp,
         solve_pnp_ransac, FundamentalMatMethod, HomographyMethod, SolvePnPMethod,
     };
+    pub use crate::core::logging::{tags, LogLevel};
     pub use crate::core::types::{
         BorderTypes, Point2f, Point2i, Point3f, Rect2f, Rect2i, Scalar, Size2f, Size2i,
         TermCriteria, TermType, Vec2b, Vec2d, Vec2f, Vec2i, Vec2s, Vec3b, Vec3d, Vec3f, Vec3i,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,17 +34,30 @@
  *
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 // Global modules
+//
+// Only `core` and `version` build without `std` for now; the remaining modules
+// are gated until their own no_std phases land (see issue #82).
+#[cfg(feature = "std")]
 pub mod calib3d;
 pub mod core;
+#[cfg(feature = "std")]
 pub mod features;
+#[cfg(feature = "std")]
 pub mod features2d;
+#[cfg(feature = "std")]
 pub mod imgproc;
 pub mod version;
+#[cfg(feature = "std")]
 pub mod video;
 
 /// Prelude to easily import common structures
 pub mod prelude {
+    #[cfg(feature = "std")]
     pub use crate::calib3d::{
         find_fundamental_mat, find_homography, init_undistort_rectify_map, rodrigues, solve_pnp,
         solve_pnp_ransac, FundamentalMatMethod, HomographyMethod, SolvePnPMethod,
@@ -55,21 +68,29 @@ pub mod prelude {
         Vec3s, Vec4b, Vec4d, Vec4f, Vec4i, Vec4s, Vec6d, Vec6f, VecN,
     };
     pub use crate::core::Matrix;
+    #[cfg(feature = "std")]
     pub use crate::features2d::{
         draw_keypoints, draw_matches, filter_matches, BFMatcher, DMatch, DescriptorMatcher,
         FastFeatureDetector, FastType, KeyPoint, NormType, Orb,
     };
+    #[cfg(feature = "std")]
     pub use crate::imgproc::derivatives::{laplacian, scharr, sobel};
+    #[cfg(feature = "std")]
     pub use crate::imgproc::edge::canny;
+    #[cfg(feature = "std")]
     pub use crate::imgproc::feature::{
         corner_eigen_vals_and_vecs, corner_harris, corner_min_eigen_val, corner_sub_pix,
         good_features_to_track, pre_corner_detect,
     };
+    #[cfg(feature = "std")]
     pub use crate::imgproc::filter::{bilateral_filter, box_filter, gaussian_blur};
+    #[cfg(feature = "std")]
     pub use crate::imgproc::threshold::{threshold, ThresholdTypes};
+    #[cfg(feature = "std")]
     pub use crate::imgproc::{
         cvt_color, remap, warp_perspective, ColorConversionCode, InterpolationFlags,
     };
+    #[cfg(feature = "std")]
     pub use crate::video::optical_flow::{
         build_optical_flow_pyramid, calc_optical_flow_pyramid_lk, OpticalFlowPyramid,
         OPTFLOW_LK_GET_MIN_EIGENVALS, OPTFLOW_USE_INITIAL_FLOW,

--- a/src/version.rs
+++ b/src/version.rs
@@ -60,7 +60,7 @@ pub fn get_version() -> &'static str {
 /// Call this early in your application (e.g. during initialization) so the
 /// version appears in the console / log output.
 pub fn print_version() {
-    log::info!("purecv v{}", VERSION);
+    crate::cv_log_info!(crate::core::logging::tags::PURECV, "purecv v{}", VERSION);
 }
 
 #[cfg(test)]

--- a/src/video/optical_flow.rs
+++ b/src/video/optical_flow.rs
@@ -53,8 +53,10 @@
 //! | `tryReuseInputImage` optimisation flag | not implemented (correctness only) |
 
 use crate::core::error::{PureCvError, Result};
+use crate::core::logging::tags;
 use crate::core::types::{BorderTypes, Point2f, Size2i, TermCriteria, TermType};
 use crate::core::Matrix;
+use crate::cv_log_debug;
 use crate::imgproc::derivatives::sobel;
 use crate::imgproc::pyramid::pyr_down;
 
@@ -366,6 +368,15 @@ fn lk_single_level(
     let det = h00 * h11 - h01 * h01;
 
     if min_eigen < min_eigen_threshold || det.abs() < f64::EPSILON {
+        cv_log_debug!(
+            tags::VIDEO,
+            "LK tracking lost at ({:.2}, {:.2}): min_eigen = {:.6} (threshold = {:.6}), det = {:.6e}",
+            px,
+            py,
+            min_eigen,
+            min_eigen_threshold,
+            det.abs()
+        );
         return (init_u, init_v, min_eigen, false);
     }
 


### PR DESCRIPTION
Makes the `core` module compile without the Rust standard library, using only `core` + `alloc`, so purecv can run on microcontrollers such as the ESP32 (#82).

`std` is now an explicit opt-in feature (still on by default — no change for existing users). With `--no-default-features`:

- `lib.rs` sets `#![cfg_attr(not(feature = "std"), no_std)]` with `extern crate alloc`
- all `std::` paths in `src/core` moved to `core::`/`alloc::`; `PureCvError` implements `core::error::Error` (MSRV set to 1.88, which the codebase already required via `is_multiple_of`)
- float math (`sqrt`, `sin`, …, 243 call sites) resolves through `num_traits::Float` backed by `libm`, since those methods don't exist on `f32`/`f64` without std
- genuinely std-only APIs are gated: `get_tick_count`/`get_tick_frequency` (no bare-metal clock) and the thread-local RNG (`set_rng_seed`, `randu`, `randn`, `rand_shuffle`)
- the not-yet-converted modules (`imgproc`, `features2d`, `video`, `calib3d`, `features`) and the `parallel`/`simd`/`fft`/`ndarray` features require `std` until their own phases land

A new build-only crate `crates/no-std-smoke` consumes the public API from a `#![no_std]` crate, and a new CI job builds both purecv and the smoke crate for `thumbv7em-none-eabihf` and lints the no-default-features configuration.

Verified: full test suite passes with default features (358 unit + 35 doc tests), clippy/fmt clean on both configurations, and matrix arithmetic ran end-to-end on real ESP32-S3 hardware (Xtensa, `esp` toolchain) with output logged over serial.

Alternative considered: splitting a `purecv-core` sub-crate for isolation — rejected for Phase 1 as the mechanical move would dominate the diff; the single-crate `cfg_attr` approach keeps the change reviewable.

Closes #83
Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)