### PR TITLE
feat(imgproc): no_std support for the imgproc module (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: cargo test --workspace --features ndarray
 
   no-std-build:
-    name: no_std Build (core only, issue #83)
+    name: no_std Build (core + imgproc, issues #83/#84)
     runs-on: ubuntu-latest
 
     steps:

--- a/crates/no-std-smoke/src/lib.rs
+++ b/crates/no-std-smoke/src/lib.rs
@@ -50,7 +50,9 @@ extern crate alloc;
 
 use alloc::vec;
 use purecv::core::error::Result;
+use purecv::core::types::{BorderTypes, Size2i};
 use purecv::core::{add, determinant, mean, Matrix};
+use purecv::imgproc::gaussian_blur;
 
 /// Exercises matrix construction, arithmetic, statistics, and linear algebra.
 pub fn smoke() -> Result<f64> {
@@ -62,4 +64,22 @@ pub fn smoke() -> Result<f64> {
     let det = determinant(&sum);
 
     Ok(avg.v[0] + det)
+}
+
+/// Exercises the Phase 2 imgproc path: a scalar `gaussian_blur` under no_std.
+pub fn smoke_imgproc() -> Result<f32> {
+    let src = Matrix::<f32>::from_vec(
+        3,
+        3,
+        1,
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+    );
+    let blurred = gaussian_blur(
+        &src,
+        Size2i::new(3, 3),
+        0.0,
+        0.0,
+        BorderTypes::Reflect101,
+    )?;
+    Ok(blurred.data[4])
 }

--- a/src/imgproc/color.rs
+++ b/src/imgproc/color.rs
@@ -34,6 +34,9 @@
  *
  */
 
+#[allow(unused_imports)]
+use num_traits::Float;
+
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/src/imgproc/derivatives.rs
+++ b/src/imgproc/derivatives.rs
@@ -34,6 +34,8 @@
  *
  */
 
+use alloc::{string::ToString, vec, vec::Vec};
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::utils::border_interpolate;
 use crate::core::{BorderTypes, Matrix};
@@ -337,15 +339,15 @@ where
     // and use the SIMD 3x3 kernel for interior rows.
     #[cfg(feature = "simd")]
     {
-        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>() && rows > 2 && cols > 2 {
+        if core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>() && rows > 2 && cols > 2 {
             let row_len = cols * channels;
 
             // Reinterpret src.data as &[f32] — safe because T == f32
             let src_f32: &[f32] = unsafe {
-                std::slice::from_raw_parts(src.data.as_ptr() as *const f32, src.data.len())
+                core::slice::from_raw_parts(src.data.as_ptr() as *const f32, src.data.len())
             };
             let dst_f32: &mut [f32] = unsafe {
-                std::slice::from_raw_parts_mut(dst.data.as_mut_ptr() as *mut f32, dst.data.len())
+                core::slice::from_raw_parts_mut(dst.data.as_mut_ptr() as *mut f32, dst.data.len())
             };
 
             // Process interior rows with SIMD

--- a/src/imgproc/edge.rs
+++ b/src/imgproc/edge.rs
@@ -34,6 +34,10 @@
  *
  */
 
+use alloc::vec::Vec;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::BorderTypes;
 use crate::core::Matrix;
@@ -117,7 +121,7 @@ where
             *m = magnitude as f32;
 
             if magnitude > 1e-5 {
-                let angle = gy_f.atan2(gx_f) * 180.0 / std::f64::consts::PI;
+                let angle = gy_f.atan2(gx_f) * 180.0 / core::f64::consts::PI;
                 let normalized_angle = if angle < 0.0 { angle + 180.0 } else { angle };
 
                 if (0.0..22.5).contains(&normalized_angle)

--- a/src/imgproc/feature.rs
+++ b/src/imgproc/feature.rs
@@ -52,6 +52,10 @@
 //!
 //! `pre_corner_detect` is an independent simpler map using first + second derivatives.
 
+use alloc::vec::Vec;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::{BorderTypes, Point2f, Size2i, TermCriteria, TermType};
 use crate::core::Matrix;
@@ -431,7 +435,7 @@ where
     }
 
     // Sort by response descending.
-    candidates.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    candidates.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(core::cmp::Ordering::Equal));
 
     // Greedily select corners with minimum distance constraint.
     let min_dist_sq = min_distance * min_distance;

--- a/src/imgproc/filter.rs
+++ b/src/imgproc/filter.rs
@@ -34,13 +34,17 @@
  *
  */
 
+use alloc::{format, string::ToString, vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::Result;
 use crate::core::types::BorderTypes;
 use crate::core::utils::border_interpolate;
 use crate::core::{Matrix, Point2i, PureCvError, Size2i};
+use core::any::TypeId;
+use core::iter::Sum;
 use num_traits::{FromPrimitive, NumCast, ToPrimitive};
-use std::any::TypeId;
-use std::iter::Sum;
 
 #[cfg(not(feature = "parallel"))]
 use crate::core::utils::ParIterFallback;
@@ -337,7 +341,8 @@ where
                         }
                     }
                     // Sort to find median
-                    neighbors.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                    neighbors
+                        .sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
                     let median = neighbors[neighbors.len() / 2];
                     *comp = median;
                 }

--- a/src/imgproc/geometric.rs
+++ b/src/imgproc/geometric.rs
@@ -34,6 +34,10 @@
  *
  */
 
+use alloc::{string::ToString, vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::arithm::{invert, DecompTypes};
 use crate::core::error::{PureCvError, Result};
 use crate::core::simd::SimdElement;

--- a/src/imgproc/hough.rs
+++ b/src/imgproc/hough.rs
@@ -34,6 +34,10 @@
  *
  */
 
+use alloc::{vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::constants::CV_PI;
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::BorderTypes;
@@ -131,7 +135,7 @@ pub fn hough_lines(
     }
 
     // Stage 3. Sort the detected lines by accumulator value descending
-    sort_buf.sort_by_key(|b| std::cmp::Reverse(b.1));
+    sort_buf.sort_by_key(|b| core::cmp::Reverse(b.1));
 
     // Stage 4. Format output
     let mut lines = Vec::with_capacity(sort_buf.len());
@@ -160,6 +164,12 @@ pub fn hough_lines(
 ///
 /// # Returns
 /// A vector of `[i32; 4]` representing `(x1, y1, x2, y2)` for each segment.
+///
+/// Requires the `std` feature: the probabilistic transform shuffles edge points
+/// with the thread-local RNG ([`crate::core::rand_shuffle`]), which is std-only
+/// until a no_std seedable RNG lands (see issue #82). The deterministic
+/// [`hough_lines`] is available under `no_std`.
+#[cfg(feature = "std")]
 pub fn hough_lines_p(
     image: &Matrix<u8>,
     rho: f64,
@@ -452,7 +462,7 @@ pub fn hough_circles(
     }
 
     // Sort centers by votes
-    centers.sort_by_key(|b| std::cmp::Reverse(b.2));
+    centers.sort_by_key(|b| core::cmp::Reverse(b.2));
 
     let mut circles = Vec::new();
 

--- a/src/imgproc/morph.rs
+++ b/src/imgproc/morph.rs
@@ -34,6 +34,13 @@
  *
  */
 
+use alloc::{string::ToString, vec::Vec};
+// `vec!` is only used by the SIMD-only separable kernel below.
+#[cfg(feature = "simd")]
+use alloc::vec;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::arithm;
 use crate::core::error::{PureCvError, Result};
 use crate::core::simd::SimdElement;

--- a/src/imgproc/pyramid.rs
+++ b/src/imgproc/pyramid.rs
@@ -39,6 +39,10 @@
 //! These functions implement the classical Gaussian pyramid using the 5-tap
 //! kernel `[1, 4, 6, 4, 1]` (sum = 16, outer product sum = 256).
 
+use alloc::{string::ToString, vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::simd::SimdElement;
 use crate::core::types::{BorderTypes, Size};

--- a/src/imgproc/resize.rs
+++ b/src/imgproc/resize.rs
@@ -36,6 +36,10 @@
 
 //! Image resizing operations: [`resize`].
 
+use alloc::string::ToString;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::Size;
 use crate::core::Matrix;

--- a/src/imgproc/threshold.rs
+++ b/src/imgproc/threshold.rs
@@ -34,6 +34,8 @@
  *
  */
 
+use alloc::string::ToString;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::simd::SimdElement;
 use crate::core::Matrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use alloc::format as __format;
 
 // Global modules
 //
-// Only `core` and `version` build without `std` for now; the remaining modules
+// `core`, `imgproc`, and `version` build without `std`; the remaining modules
 // are gated until their own no_std phases land (see issue #82).
 #[cfg(feature = "std")]
 pub mod calib3d;
@@ -56,7 +56,6 @@ pub mod core;
 pub mod features;
 #[cfg(feature = "std")]
 pub mod features2d;
-#[cfg(feature = "std")]
 pub mod imgproc;
 pub mod version;
 #[cfg(feature = "std")]
@@ -81,20 +80,14 @@ pub mod prelude {
         draw_keypoints, draw_matches, filter_matches, BFMatcher, DMatch, DescriptorMatcher,
         FastFeatureDetector, FastType, KeyPoint, NormType, Orb,
     };
-    #[cfg(feature = "std")]
     pub use crate::imgproc::derivatives::{laplacian, scharr, sobel};
-    #[cfg(feature = "std")]
     pub use crate::imgproc::edge::canny;
-    #[cfg(feature = "std")]
     pub use crate::imgproc::feature::{
         corner_eigen_vals_and_vecs, corner_harris, corner_min_eigen_val, corner_sub_pix,
         good_features_to_track, pre_corner_detect,
     };
-    #[cfg(feature = "std")]
     pub use crate::imgproc::filter::{bilateral_filter, box_filter, gaussian_blur};
-    #[cfg(feature = "std")]
     pub use crate::imgproc::threshold::{threshold, ThresholdTypes};
-    #[cfg(feature = "std")]
     pub use crate::imgproc::{
         cvt_color, remap, warp_perspective, ColorConversionCode, InterpolationFlags,
     };


### PR DESCRIPTION
Makes the `imgproc` module compile under `no_std + alloc` with `--no-default-features`, using scalar fallbacks (parallel & SIMD disabled). Second step of #82, building on Phase 1 (#83).

`imgproc` is un-gated in `lib.rs` and now builds with only `core` + `alloc`. The change is almost entirely mechanical:

- `std::` paths → their `core::` equivalents (`any::TypeId`, `iter::Sum`, `slice::from_raw_parts`, `f64::consts::PI`, `cmp::Ordering`, `cmp::Reverse`)
- `alloc::{vec, vec::Vec, format, string::ToString}` imports where used
- concrete `f32`/`f64` math (`sqrt`, `floor`, `round`, `exp`, `atan2`, …) resolves through `num_traits::Float` (libm) in no_std builds, same pattern as core
- `hough_lines_p` (probabilistic Hough) is gated behind `std`: it shuffles edge points with the thread-local RNG (`rand_shuffle`), which stays std-only until a no_std seedable RNG lands (a Phase-1 follow-up, see #82). The deterministic `hough_lines` remains available on no_std.

Rayon (`parallel`) and `pulp` (`simd`) were already feature-gated and both imply `std` since Phase 1, so they compile out on bare metal with no further work — the scalar path is the sequential branch that was always there.

The `crates/no-std-smoke` consumer now also exercises `gaussian_blur`, and the CI `no_std Build` job (already building `--no-default-features` for `thumbv7em-none-eabihf`) now covers imgproc too.

Verified: 308 lib + 40 doctests pass with default features; clippy/fmt clean on no-default / default / simd+parallel; builds for `thumbv7em-none-eabihf`; and the ESP32-S3 example runs correctly on real hardware against this tree.

Out of scope (Phase 3, #85): video and calib3d.

Closes #84
Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)