### PR TITLE
feat(video,calib3d): no_std support (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: cargo test --workspace --features ndarray
 
   no-std-build:
-    name: no_std Build (core + imgproc, issues #83/#84)
+    name: no_std Build (core + imgproc + calib3d + video, issues #83/#84/#85)
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -91,11 +91,30 @@ purecv = "0.5"
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `std` | ✅ | Standard library support |
-| `parallel` | ✅ | Multi-core parallelism via **Rayon** |
+| `std` | ✅ | Standard library support (disable for `no_std` — see below) |
+| `parallel` | ✅ | Multi-core parallelism via **Rayon** (implies `std`) |
 | `ndarray` | ❌ | Interop with the `ndarray` crate (zero-cost views & ownership transfers) |
-| `simd` | ❌ | SIMD acceleration via [`pulp`](https://crates.io/crates/pulp) (x86 SSE/AVX, ARM NEON, WASM `simd128`) |
+| `simd` | ❌ | SIMD acceleration via [`pulp`](https://crates.io/crates/pulp) (x86 SSE/AVX, ARM NEON, WASM `simd128`) — implies `std` |
 | `wasm` | ❌ | WebAssembly-specific optimizations |
+
+### `no_std` / embedded support
+
+Build with `--no-default-features` to run on bare-metal targets such as the
+ESP32 (`purecv = { version = "0.6", default-features = false }`). Only `core`
+and `alloc` are required (an allocator must be provided by the target).
+
+| Module | `no_std` | Notes |
+|--------|----------|-------|
+| `core` | ✅ | Full support. `get_tick_count`/`get_tick_frequency` and the thread-local RNG (`randu`/`randn`/`rand_shuffle`) require `std`. |
+| `imgproc` | ✅ | Scalar fallbacks. `hough_lines_p` requires `std` (uses the thread-local RNG); `hough_lines` works without. |
+| `calib3d` | ✅ | Full support (RANSAC uses a self-contained PRNG). |
+| `video` | ✅ | Full support. Optical-flow pyramids are heap-heavy — size images for your device's RAM. |
+| `features2d` | ❌ | Requires `std` for now. |
+
+`parallel`, `simd`, `fft`, and `ndarray` require `std`; disabling default
+features gives the scalar, single-threaded code paths. See
+[`webarkit/purecv-esp32-examples`](https://github.com/webarkit/purecv-esp32-examples)
+for runnable ESP32-S3 demos.
 
 To enable the `ndarray` feature:
 

--- a/crates/no-std-smoke/src/lib.rs
+++ b/crates/no-std-smoke/src/lib.rs
@@ -49,10 +49,12 @@
 extern crate alloc;
 
 use alloc::vec;
+use purecv::calib3d::rodrigues;
 use purecv::core::error::Result;
 use purecv::core::types::{BorderTypes, Size2i};
 use purecv::core::{add, determinant, mean, Matrix};
 use purecv::imgproc::gaussian_blur;
+use purecv::video::build_optical_flow_pyramid;
 
 /// Exercises matrix construction, arithmetic, statistics, and linear algebra.
 pub fn smoke() -> Result<f64> {
@@ -82,4 +84,26 @@ pub fn smoke_imgproc() -> Result<f32> {
         BorderTypes::Reflect101,
     )?;
     Ok(blurred.data[4])
+}
+
+/// Exercises the Phase 3 calib3d path: `rodrigues` (rotation vector -> matrix).
+pub fn smoke_calib3d() -> Result<f64> {
+    let rvec = Matrix::<f64>::from_vec(3, 1, 1, vec![0.1, 0.2, 0.3]);
+    let mut rmat = Matrix::<f64>::new(3, 3, 1);
+    rodrigues(&rvec, &mut rmat)?;
+    Ok(rmat.data[0])
+}
+
+/// Exercises the Phase 3 video path: build a Lucas-Kanade optical-flow pyramid.
+pub fn smoke_video() -> Result<usize> {
+    let img = Matrix::<u8>::from_vec(8, 8, 1, vec![0u8; 64]);
+    let pyr = build_optical_flow_pyramid(
+        &img,
+        Size2i::new(3, 3),
+        1,
+        false,
+        BorderTypes::Reflect101,
+        BorderTypes::Reflect101,
+    )?;
+    Ok(pyr.levels.len())
 }

--- a/src/calib3d/fundamental.rs
+++ b/src/calib3d/fundamental.rs
@@ -34,6 +34,10 @@
  *
  */
 
+use alloc::{string::ToString, vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use super::linalg::{mat3_mul, null_space_vector, svd_3x3, Lcg};
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::Point2f;

--- a/src/calib3d/geometry.rs
+++ b/src/calib3d/geometry.rs
@@ -39,6 +39,10 @@
 //! Converts between a *rotation vector* (compact axis-angle representation,
 //! sometimes called an *Rodrigues vector*) and a 3×3 *rotation matrix*.
 
+use alloc::{string::ToString, vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::Matrix;
 
@@ -166,7 +170,7 @@ pub(super) fn rmat_to_rvec(m: &[f64; 9]) -> [f64; 3] {
     }
 
     // Near π the formula becomes numerically unstable; use an alternative.
-    if (theta - std::f64::consts::PI).abs() < 1e-4 {
+    if (theta - core::f64::consts::PI).abs() < 1e-4 {
         return rmat_to_rvec_near_pi(m, theta);
     }
 

--- a/src/calib3d/homography.rs
+++ b/src/calib3d/homography.rs
@@ -40,6 +40,10 @@
 //! point normalization, plus an optional RANSAC wrapper for robustness
 //! against outliers.
 
+use alloc::{format, string::ToString, vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::Point2f;
 use crate::core::Matrix;
@@ -359,7 +363,7 @@ fn normalize_points(pts: &[Point2f]) -> (Vec<f64>, [f64; 9]) {
     let s = if mean_dist < 1e-12 {
         1.0
     } else {
-        std::f64::consts::SQRT_2 / mean_dist
+        core::f64::consts::SQRT_2 / mean_dist
     };
 
     let mut out = vec![0.0f64; pts.len() * 2];

--- a/src/calib3d/linalg.rs
+++ b/src/calib3d/linalg.rs
@@ -38,6 +38,10 @@
 //!
 //! All functions operate on flat, row-major `f64` slices/arrays.
 
+use alloc::{vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 // ---------------------------------------------------------------------------
 // Matrix utilities
 // ---------------------------------------------------------------------------
@@ -204,7 +208,7 @@ pub(super) fn null_space_vector(a: &[f64], rows: usize, cols: usize) -> Vec<f64>
         .min_by(|&i, &j| {
             ata[i * cols + i]
                 .partial_cmp(&ata[j * cols + j])
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .unwrap_or(core::cmp::Ordering::Equal)
         })
         .unwrap_or(cols - 1);
 
@@ -241,7 +245,7 @@ pub(super) fn svd_3x3(a: &[f64; 9]) -> ([f64; 9], [f64; 3], [f64; 9]) {
     idx.sort_by(|&i, &j| {
         ata[j * 3 + j]
             .partial_cmp(&ata[i * 3 + i])
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .unwrap_or(core::cmp::Ordering::Equal)
     });
 
     // Reorder V columns (right singular vectors).

--- a/src/calib3d/pose.rs
+++ b/src/calib3d/pose.rs
@@ -40,6 +40,10 @@
 //! camera intrinsic matrix, these functions estimate the object pose
 //! (rotation and translation vectors) in the camera coordinate system.
 
+use alloc::{format, string::ToString, vec, vec::Vec};
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::logging::tags;
 use crate::core::types::{Point2f, Point3f};

--- a/src/calib3d/undistort.rs
+++ b/src/calib3d/undistort.rs
@@ -34,6 +34,10 @@
  *
  */
 
+use alloc::string::ToString;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::types::Size2i;
 use crate::core::Matrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,8 @@ pub use alloc::format as __format;
 
 // Global modules
 //
-// `core`, `imgproc`, and `version` build without `std`; the remaining modules
-// are gated until their own no_std phases land (see issue #82).
-#[cfg(feature = "std")]
+// `core`, `imgproc`, `calib3d`, `video`, and `version` build without `std`; the
+// `features`/`features2d` modules remain std-gated (see issue #82).
 pub mod calib3d;
 pub mod core;
 #[cfg(feature = "std")]
@@ -58,12 +57,10 @@ pub mod features;
 pub mod features2d;
 pub mod imgproc;
 pub mod version;
-#[cfg(feature = "std")]
 pub mod video;
 
 /// Prelude to easily import common structures
 pub mod prelude {
-    #[cfg(feature = "std")]
     pub use crate::calib3d::{
         find_fundamental_mat, find_homography, init_undistort_rectify_map, rodrigues, solve_pnp,
         solve_pnp_ransac, FundamentalMatMethod, HomographyMethod, SolvePnPMethod,
@@ -91,7 +88,6 @@ pub mod prelude {
     pub use crate::imgproc::{
         cvt_color, remap, warp_perspective, ColorConversionCode, InterpolationFlags,
     };
-    #[cfg(feature = "std")]
     pub use crate::video::optical_flow::{
         build_optical_flow_pyramid, calc_optical_flow_pyramid_lk, OpticalFlowPyramid,
         OPTFLOW_LK_GET_MIN_EIGENVALS, OPTFLOW_USE_INITIAL_FLOW,

--- a/src/video/optical_flow.rs
+++ b/src/video/optical_flow.rs
@@ -52,6 +52,13 @@
 //! | `calcOpticalFlowPyrLK` `nextPts` is `InputOutputArray` | initial guess passed via `initial_next_pts: Option<&[Point2f]>` |
 //! | `tryReuseInputImage` optimisation flag | not implemented (correctness only) |
 
+use alloc::{string::ToString, vec::Vec};
+// `vec!` is only used by the SIMD-only windowed kernel below.
+#[cfg(feature = "simd")]
+use alloc::vec;
+#[allow(unused_imports)]
+use num_traits::Float;
+
 use crate::core::error::{PureCvError, Result};
 use crate::core::logging::tags;
 use crate::core::types::{BorderTypes, Point2f, Size2i, TermCriteria, TermType};

--- a/src/video/simd.rs
+++ b/src/video/simd.rs
@@ -56,6 +56,9 @@
 //! kernels operate *after* the gather, on the pre-collected contiguous `f32`
 //! buffers, where auto-vectorisation applies cleanly.
 
+#[allow(unused_imports)]
+use num_traits::Float;
+
 // ---------------------------------------------------------------------------
 // H matrix accumulation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Concludes the exploratory Phase 3 (#85) with **"port both"** and implements it: `video` (optical flow) and `calib3d` (pose estimation, SVD) now compile under `no_std + alloc`.

## Why port (the exploration result)

The audit found **no hard blockers**:

- **std usage** was minimal — `video` had none, `calib3d` had 4 trivial `std::` paths (`f64::consts`, `cmp::Ordering`).
- **calib3d RANSAC** (`solve_pnp_ransac`, `find_homography`, `find_fundamental_mat`) uses its own self-contained `Lcg` PRNG (fixed-seed, pure arithmetic), **not** the std-gated thread-local RNG that forced `hough_lines_p` to stay std-only in Phase 2.
- No `HashMap`, `Instant`, `thread_local`, or `println` in either module.
- The empirical probe produced **137 errors, all mechanical** — the exact `Vec`/`vec!`/`to_string`/`Float`/`std::`→`core::`/`format!` classes as Phase 2.

Memory: calib3d's SVD runs on tiny matrices (trivial); `video`'s optical-flow pyramids are heap-heavy but feasible at low resolution — documented as the one caveat.

## Changes

- Un-gate `video` + `calib3d` (module + prelude re-exports) in `lib.rs`.
- Mechanical `std::`→`core::`, `alloc` imports, and `num_traits::Float` where concrete `f32`/`f64` math is used. `optical_flow`'s SIMD-only `vec!` import is gated behind `simd`.
- `crates/no-std-smoke` now also exercises `rodrigues` (calib3d) and `build_optical_flow_pyramid` (video), so the bare-metal build covers all four no_std modules.
- CI `no_std Build` job renamed to cover core + imgproc + calib3d + video.
- README: new "`no_std` / embedded support" section with a per-module support matrix (satisfies #85's documentation acceptance criterion).

## Verification

- `--no-default-features` builds clean on host and `thumbv7em-none-eabihf`.
- 308 lib + 40 doc tests pass with default features; clippy/fmt clean on no-default / default / simd+parallel.
- The no_std smoke crate builds for `thumbv7em` exercising all four modules; ESP32-S3 examples build against this tree.

After this, the whole `core` + `imgproc` + `calib3d` + `video` surface is `no_std`; only `features2d` remains std-gated.

Closes #85
Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)