### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2026-08-07
+
+### ⚙️ Miscellaneous Tasks
+
+- *(core)* Make std an explicit opt-in feature, set MSRV 1.88
+- *(ci)* Add no_std build job
+- *(core)* Fix formatting in logging.rs (#80)
+
+### 🐛 Bug Fixes
+
+- *(wasm)* Re-enable purecv std feature for the wasm crate
+
+### 📚 Documentation
+
+- Document no_std/embedded support and refresh the README
+- *(core)* Document the logging facility in the README (#80)
+- *(core)* Add module-level docs for core, imgproc and features (#80)
+
+### 🚀 Features
+
+- *(core)* Compile the core module without the standard library
+- *(imgproc)* Compile the imgproc module without the standard library
+- *(video,calib3d)* Compile both modules without the standard library
+- *(core)* Add OpenCV-style logging facade (#80)
+- *(core)* Add basic logger and migrate example applications to logging macros (#80)
+- *(core)* Add cv_bail!/cv_err! log-and-return macros (#80)
+- *(core)* Add warning logs for solve and solve_pnp_ransac failure cases (#80)
+- *(core)* Log input-validation failures in arithm and matrix (#80)
+- *(core)* Log input-validation failures across remaining core modules (#80)
+- *(video)* Add debug logging inside calc_optical_flow_pyramid_lk (#80)
+
+### 🚜 Refactor
+
+- *(core)* Gate the stdout logger behind the std feature (#80)
+- *(imgproc)* Use core::/alloc:: paths for no_std
+- *(video,calib3d)* Use core::/alloc:: paths for no_std
+
+### 🧪 Testing
+
+- *(core)* Add build-only no_std smoke-test crate
+- *(imgproc)* Exercise gaussian_blur from the no_std smoke crate
+- *(video,calib3d)* Smoke-test both modules + document no_std support
+
 ## [0.6.1] - 2026-07-08
 
 ### 🎨 Styling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purecv"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Walter Perdan <https://github.com/kalwalt>"]
 edition = "2021"
 rust-version = "1.88"
@@ -86,7 +86,7 @@ members = ["crates/wasm"]
 exclude = ["crates/no-std-smoke"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Walter Perdan <https://github.com/kalwalt>"]
 edition = "2021"
 description = "A pure Rust, high-performance computer vision library focused on safety and portability."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purecv",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A pure Rust, high-performance computer vision library focused on safety and portability.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release preparation for **v0.7.0** — the `no_std` / embedded milestone.

Bumps the version `0.6.1 → 0.7.0` (minor: new backward-compatible feature; default features and existing APIs unchanged) across `Cargo.toml` (`[package]` + `[workspace.package]`) and `package.json`, and adds the `0.7.0` `CHANGELOG.md` section.

Headline changes since v0.6.1:
- **`no_std` / embedded support** across `core`, `imgproc`, `calib3d`, and `video` (issues #82/#83/#84/#85).
- **OpenCV-style logging facade** with `cv_log_*!` / `cv_bail!` / `cv_err!` (#80).
- MSRV set to **1.88**.

After this merges, the `dev → main` promotion PR will carry the release to `main` for tagging.

> The `CHANGELOG.md` entry was hand-written to match `cliff.toml`'s grouping; regenerate byte-perfect with `git cliff` if preferred (the release workflow generates the GitHub Release notes automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)