### PR TITLE
doc: record the release workflow and merge policy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,29 @@ Preferred scopes: `(core)` `(imgproc)` `(simd)` `(wasm)` `(parallel)`
 - PRs start from and target the `dev` branch (not `main`).
 - Keep PRs focused; one feature or fix per PR.
 
+### Releases
+
+Releases go `dev` → PR to `main` → merge → tag `vX.Y.Z` on `main`. Pushing the tag
+triggers `release.yml`, which publishes to crates.io **and** npm — irreversible.
+
+**Merge release PRs with a merge commit, not "Rebase and merge" or "Squash and
+merge".** Rebasing replays dev's commits as new objects on `main`, so `dev` stops
+being an ancestor of `main` and the two diverge with identical content but different
+SHAs. The next release PR then replays every old commit again. This happened with
+v0.7.1 (#95) and had to be repaired by resetting `dev` to `main`.
+
+Release prep steps (see the v0.7.1 commit for a worked example):
+
+1. Bump the version in `Cargo.toml` (**two places** — `[package]` and
+   `[workspace.package]`) and in the root `package.json`.
+2. Run `npm run build` — this regenerates `crates/wasm/pkg/package.json`, which is
+   tracked and otherwise silently drifts.
+3. `npx git-cliff --config cliff.toml --tag vX.Y.Z --unreleased --prepend CHANGELOG.md`,
+   then add the blank line `--prepend` omits before the previous version heading.
+4. Commit as `chore(release): prepare for vX.Y.Z` — `cliff.toml` skips this message
+   from the changelog, so land any other changes in their own commits *first* or they
+   will not appear.
+
 ## Module Structure Convention
 
 Each top-level module (`core/`, `imgproc/`, `features2d/`, etc.) must contain its own:


### PR DESCRIPTION
Documents the release process in `CLAUDE.md`. Two things went wrong during v0.7.1 and neither was written down anywhere.

## Merge policy — the one that actually caused damage

PR #95 was merged with **"Rebase and merge"**, which replayed dev's commits as new objects on `main`. The result was identical file content but divergent history: 8 commits on each side with the same messages and different SHAs, and `dev` no longer an ancestor of `main`. Left alone, the next release PR would have replayed all of them again.

Repaired by resetting `dev` to `main` (safe — `git cherry` confirmed every dev commit was already applied, and the tree diff was empty). Both branches are now at `dc05ec3`.

Your previous release (#92) used a merge commit and did not have this problem, so the policy is now explicit: **release PRs merge with a merge commit.**

## The npm build step

`npm run build` regenerates `crates/wasm/pkg/package.json`, which is tracked. It had drifted to a full release behind — sitting at 0.6.1 while 0.7.0 was live on npm. Harmless in practice, since `release.yml`'s `publish-npm` job rebuilds the package before publishing and never reads the committed copy, but the repo was contradicting itself.

## Also recorded

- `Cargo.toml` holds the version in **two** places (`[package]` and `[workspace.package]`) — easy to bump one and miss the other
- The `git-cliff` invocation, and that `--prepend` omits the blank line before the previous version heading
- `cliff.toml` skips `chore(release): prepare for…` commits, so any other change must land in its own commit *first* or it will be missing from the changelog

Docs only — no code, no CI changes.