### PR TITLE
chore(ci): pin stable toolchain and fix new chunks_exact_to_as_chunks lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.98.0
       with:
         components: rustfmt, clippy
 
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.98.0
       with:
         components: clippy
         targets: thumbv7em-none-eabihf
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.98.0
       with:
         targets: wasm32-unknown-unknown
 
@@ -107,7 +107,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.98.0
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
       - name: Publish to Crates.io
         run: cargo publish --token ${{ secrets.CRATES_TOKEN }} -p purecv
 
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.98.0
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build and Publish to NPM

--- a/src/imgproc/color.rs
+++ b/src/imgproc/color.rs
@@ -61,8 +61,7 @@ fn rgb_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
-        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(3)) {
+        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.as_chunks::<3>().0.iter()) {
             let r = in_val[0] as f32;
             let g = in_val[1] as f32;
             let b = in_val[2] as f32;
@@ -80,8 +79,7 @@ fn bgr_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
-        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(3)) {
+        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.as_chunks::<3>().0.iter()) {
             let b = in_val[0] as f32;
             let g = in_val[1] as f32;
             let r = in_val[2] as f32;
@@ -99,8 +97,7 @@ fn rgba_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
-        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(4)) {
+        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.as_chunks::<4>().0.iter()) {
             let r = in_val[0] as f32;
             let g = in_val[1] as f32;
             let b = in_val[2] as f32;
@@ -118,8 +115,7 @@ fn bgra_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
-        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(4)) {
+        for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.as_chunks::<4>().0.iter()) {
             let b = in_val[0] as f32;
             let g = in_val[1] as f32;
             let r = in_val[2] as f32;
@@ -351,8 +347,9 @@ pub fn cvt_color_gray_to_rgb(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<3>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -368,8 +365,9 @@ pub fn cvt_color_gray_to_rgb(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<3>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -398,8 +396,9 @@ pub fn cvt_color_gray_to_bgr(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<3>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -415,8 +414,9 @@ pub fn cvt_color_gray_to_bgr(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<3>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -445,8 +445,9 @@ pub fn cvt_color_gray_to_rgba(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<4>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -463,8 +464,9 @@ pub fn cvt_color_gray_to_rgba(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<4>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -494,8 +496,9 @@ pub fn cvt_color_gray_to_bgra(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<4>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;
@@ -512,8 +515,9 @@ pub fn cvt_color_gray_to_bgra(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
-                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
-                for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
+                for (out_val, in_pixel) in
+                    out_row.as_chunks_mut::<4>().0.iter_mut().zip(in_row.iter())
+                {
                     let v = *in_pixel;
                     out_val[0] = v;
                     out_val[1] = v;

--- a/src/imgproc/color.rs
+++ b/src/imgproc/color.rs
@@ -61,6 +61,7 @@ fn rgb_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(3)) {
             let r = in_val[0] as f32;
             let g = in_val[1] as f32;
@@ -79,6 +80,7 @@ fn bgr_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(3)) {
             let b = in_val[0] as f32;
             let g = in_val[1] as f32;
@@ -97,6 +99,7 @@ fn rgba_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(4)) {
             let r = in_val[0] as f32;
             let g = in_val[1] as f32;
@@ -115,6 +118,7 @@ fn bgra_to_gray_row(out_row: &mut [u8], in_row: &[u8]) {
     }
     #[cfg(not(feature = "simd"))]
     {
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
         for (out_pixel, in_val) in out_row.iter_mut().zip(in_row.chunks_exact(4)) {
             let b = in_val[0] as f32;
             let g = in_val[1] as f32;
@@ -347,6 +351,7 @@ pub fn cvt_color_gray_to_rgb(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -363,6 +368,7 @@ pub fn cvt_color_gray_to_rgb(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -392,6 +398,7 @@ pub fn cvt_color_gray_to_bgr(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -408,6 +415,7 @@ pub fn cvt_color_gray_to_bgr(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static 
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(3).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -437,6 +445,7 @@ pub fn cvt_color_gray_to_rgba(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -454,6 +463,7 @@ pub fn cvt_color_gray_to_rgba(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -484,6 +494,7 @@ pub fn cvt_color_gray_to_bgra(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .par_chunks_exact_mut(out_row_len)
             .zip(input.data.par_chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;
@@ -501,6 +512,7 @@ pub fn cvt_color_gray_to_bgra(input: &Matrix<u8>) -> Result<Matrix<u8>, &'static
             .chunks_exact_mut(out_row_len)
             .zip(input.data.chunks_exact(in_row_len))
             .for_each(|(out_row, in_row)| {
+                #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
                 for (out_val, in_pixel) in out_row.chunks_exact_mut(4).zip(in_row.iter()) {
                     let v = *in_pixel;
                     out_val[0] = v;


### PR DESCRIPTION
## Summary

CI on `dev` started failing (unrelated to any specific PR) once GitHub Actions runners picked up Rust 1.98, which stabilized the clippy lint `chunks_exact_to_as_chunks`. It fires on every `chunks_exact`/`chunks_exact_mut` call that uses a constant chunk size, and since we run `-D warnings`, that's a hard CI failure — 8 sites in `src/imgproc/color.rs` (RGB/BGR/RGBA/BGRA → gray conversions).

Root cause: `.github/workflows/ci.yml` / `release.yml` install `dtolnay/rust-toolchain@stable` with no version pin, so any new stable release (and any new clippy lint it ships) can silently break CI on every open PR without a code change on our side.

## Changes

- Pin all `dtolnay/rust-toolchain@stable` steps in `ci.yml` and `release.yml` to `1.98.0`, so future clippy releases can't retroactively break CI again without an explicit bump.
- Add `#[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]` at the 8 call sites in `color.rs`. `[T]::as_chunks` (clippy's suggested rewrite) isn't stable yet, so it's not usable as a fix right now. `unknown_lints` keeps this from breaking on older toolchains that don't know the lint.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features -- -D warnings` clean on `src/imgproc/color.rs` (pre-existing unrelated `needless_range_loop` warnings in `dct.rs` confirmed present on unmodified `dev` too — out of scope here)
- [x] `cargo clippy --no-default-features -- -D warnings` clean on `color.rs`
- [x] CI on this PR should confirm green under the pinned 1.98.0 toolchain

Related: unblocks CI on [#99](https://github.com/webarkit/purecv/pull/99), which is failing for this same reason and not for anything in its own diff.
