### PR TITLE
feat(imgproc): add parallel support to histogram module

### DIFF
--- a/benches/imgproc_bench.rs
+++ b/benches/imgproc_bench.rs
@@ -41,6 +41,7 @@ use purecv::imgproc::derivatives::{laplacian, scharr, sobel};
 use purecv::imgproc::edge::canny;
 use purecv::imgproc::feature::corner_harris;
 use purecv::imgproc::filter::{bilateral_filter, box_filter, gaussian_blur};
+use purecv::imgproc::histogram::{calc_back_project, calc_hist, equalize_hist, Clahe, RangeSpec};
 use purecv::imgproc::hough::{hough_circles, hough_lines, hough_lines_p};
 use purecv::imgproc::threshold::{threshold, ThresholdTypes};
 use purecv::imgproc::{cvt_color, ColorConversionCode};
@@ -253,6 +254,57 @@ fn bench_imgproc(c: &mut Criterion) {
             )
             .unwrap()
         })
+    });
+
+    // calc_hist benchmark setup
+    let mut img_hist = Matrix::<u8>::new(size, size, 1);
+    for (i, p) in img_hist.data.iter_mut().enumerate() {
+        *p = (i % 256) as u8;
+    }
+    let hist_ranges = [RangeSpec::Uniform(0.0, 256.0)];
+
+    c.bench_function("calc_hist_1024x1024", |b| {
+        b.iter(|| {
+            calc_hist(
+                black_box(&[&img_hist]),
+                &[0],
+                None,
+                &[256],
+                &hist_ranges,
+                false,
+                None,
+            )
+            .unwrap()
+        })
+    });
+
+    // calc_back_project benchmark setup
+    let hist_for_backproj =
+        calc_hist(&[&img_hist], &[0], None, &[256], &hist_ranges, false, None).unwrap();
+
+    c.bench_function("calc_back_project_1024x1024", |b| {
+        b.iter(|| {
+            calc_back_project(
+                black_box(&[&img_hist]),
+                &[0],
+                &hist_for_backproj,
+                &hist_ranges,
+                1.0,
+            )
+            .unwrap()
+        })
+    });
+
+    // equalize_hist benchmark setup
+    c.bench_function("equalize_hist_1024x1024", |b| {
+        b.iter(|| equalize_hist(black_box(&img_hist)).unwrap())
+    });
+
+    // Clahe::apply_u8 benchmark setup
+    let clahe = Clahe::new(2.0, Size2i::new(8, 8));
+
+    c.bench_function("clahe_apply_u8_1024x1024", |b| {
+        b.iter(|| clahe.apply_u8(black_box(&img_hist)).unwrap())
     });
 }
 

--- a/src/imgproc/histogram.rs
+++ b/src/imgproc/histogram.rs
@@ -476,6 +476,12 @@ pub fn calc_back_project<T: ToPrimitive + Clone + Default + Send + Sync>(
 
     let mut dst = Matrix::<f32>::new(rows, cols, 1);
 
+    // `chunks_mut`/`par_chunks_mut` panic on a zero chunk size regardless of
+    // slice length, so a zero-width input must bail out before reaching them.
+    if cols == 0 {
+        return Ok(dst);
+    }
+
     let process_row = |y: usize, dst_row: &mut [f32]| {
         for (x, out_pixel) in dst_row.iter_mut().enumerate() {
             let mut bin_idx = 0usize;
@@ -1619,6 +1625,20 @@ mod tests {
             calc_back_project::<u8>(&[&img], &[], &hist, &[RangeSpec::Uniform(0.0, 4.0)], 1.0,)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn test_calc_back_project_zero_width() {
+        // Regression test: chunks_mut/par_chunks_mut panic on a zero chunk
+        // size regardless of slice length, so a zero-width image must not
+        // reach the row-chunking dispatch.
+        let img = Matrix::<u8>::from_vec(3, 0, 1, vec![]);
+        let hist = Matrix::from_vec(4, 1, 1, vec![0.0; 4]);
+        let dst =
+            calc_back_project(&[&img], &[0], &hist, &[RangeSpec::Uniform(0.0, 4.0)], 1.0).unwrap();
+        assert_eq!(dst.rows, 3);
+        assert_eq!(dst.cols, 0);
+        assert_eq!(dst.data.len(), 0);
     }
 
     #[test]

--- a/src/imgproc/histogram.rs
+++ b/src/imgproc/histogram.rs
@@ -48,6 +48,9 @@ use crate::core::utils::border_interpolate;
 use crate::core::Matrix;
 use crate::cv_bail;
 
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
 // ---------------------------------------------------------------------------
 //  Enums
 // ---------------------------------------------------------------------------
@@ -186,7 +189,7 @@ fn map_bin(val: f32, range: &RangeSpec, hist_size: usize) -> Option<usize> {
 ///   On first call, pass `None` for `hist` or create a zero histogram.
 ///
 /// Returns a flattened `Matrix<f32>` histogram of size `(product(hist_size), 1, 1)`.
-pub fn calc_hist<T: ToPrimitive + Clone + Default>(
+pub fn calc_hist<T: ToPrimitive + Clone + Default + Send + Sync>(
     images: &[&Matrix<T>],
     channels: &[usize],
     mask: Option<&Matrix<u8>>,
@@ -342,7 +345,7 @@ pub fn calc_hist<T: ToPrimitive + Clone + Default>(
         strides[i] = strides[i + 1] * hist_size[i + 1];
     }
 
-    for y in 0..rows {
+    let accumulate_row = |local: &mut [f32], y: usize| {
         for x in 0..cols {
             if let Some(m) = mask {
                 if let Some(&v) = m.get(y, x, 0) {
@@ -367,8 +370,40 @@ pub fn calc_hist<T: ToPrimitive + Clone + Default>(
             }
 
             if !out_of_range {
-                hist_data[bin_idx] += 1.0;
+                local[bin_idx] += 1.0;
             }
+        }
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        let partial = (0..rows)
+            .into_par_iter()
+            .fold(
+                || vec![0.0f32; total_bins],
+                |mut local, y| {
+                    accumulate_row(&mut local, y);
+                    local
+                },
+            )
+            .reduce(
+                || vec![0.0f32; total_bins],
+                |mut a, b| {
+                    for (av, bv) in a.iter_mut().zip(b.iter()) {
+                        *av += bv;
+                    }
+                    a
+                },
+            );
+        for (hv, pv) in hist_data.iter_mut().zip(partial.iter()) {
+            *hv += pv;
+        }
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    {
+        for y in 0..rows {
+            accumulate_row(&mut hist_data, y);
         }
     }
 
@@ -389,7 +424,7 @@ pub fn calc_hist<T: ToPrimitive + Clone + Default>(
 ///
 /// Returns a single-channel `Matrix<f32>` of the same size as `images[0]`.
 /// Values are scaled and clamped to `[0.0, 255.0]` matching OpenCV's u8 output range.
-pub fn calc_back_project<T: ToPrimitive + Clone + Default>(
+pub fn calc_back_project<T: ToPrimitive + Clone + Default + Send + Sync>(
     images: &[&Matrix<T>],
     channels: &[usize],
     hist: &Matrix<f32>,
@@ -441,8 +476,8 @@ pub fn calc_back_project<T: ToPrimitive + Clone + Default>(
 
     let mut dst = Matrix::<f32>::new(rows, cols, 1);
 
-    for y in 0..rows {
-        for x in 0..cols {
+    let process_row = |y: usize, dst_row: &mut [f32]| {
+        for (x, out_pixel) in dst_row.iter_mut().enumerate() {
             let mut bin_idx = 0usize;
             let mut out_of_range = false;
 
@@ -457,12 +492,28 @@ pub fn calc_back_project<T: ToPrimitive + Clone + Default>(
                 }
             }
 
-            let pixel = if out_of_range {
+            *out_pixel = if out_of_range {
                 0.0f32
             } else {
                 (hist.data[bin_idx] * scale).clamp(0.0, 255.0)
             };
-            dst.set(y, x, 0, pixel);
+        }
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        dst.data
+            .par_chunks_mut(cols)
+            .enumerate()
+            .for_each(|(y, dst_row)| {
+                process_row(y, dst_row);
+            });
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    {
+        for (y, dst_row) in dst.data.chunks_mut(cols).enumerate() {
+            process_row(y, dst_row);
         }
     }
 
@@ -670,8 +721,22 @@ pub fn equalize_hist(src: &Matrix<u8>) -> Result<Matrix<u8>> {
     }
 
     let mut dst = Matrix::<u8>::new(src.rows, src.cols, 1);
-    for idx in 0..src.data.len() {
-        dst.data[idx] = lut[src.data[idx] as usize];
+
+    #[cfg(feature = "parallel")]
+    {
+        dst.data
+            .par_iter_mut()
+            .zip(src.data.par_iter())
+            .for_each(|(d, &s)| {
+                *d = lut[s as usize];
+            });
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    {
+        for (d, &s) in dst.data.iter_mut().zip(src.data.iter()) {
+            *d = lut[s as usize];
+        }
     }
 
     Ok(dst)
@@ -847,7 +912,7 @@ impl Clahe {
         };
         let mut lut = vec![0u8; lut_len];
 
-        for tile_idx in 0..num_tiles {
+        let build_tile_lut = |tile_idx: usize, tile_lut: &mut [u8]| {
             let ty = tile_idx / self.tiles_x;
             let tx = tile_idx % self.tiles_x;
             let y0 = ty * tile_rows;
@@ -866,11 +931,26 @@ impl Clahe {
 
             clip_and_redistribute(&mut tile_hist, clip_limit, hist_size);
 
-            let tile_lut = &mut lut[tile_idx * hist_size..(tile_idx + 1) * hist_size];
             let mut sum = 0i32;
             for bin in 0..hist_size {
                 sum += tile_hist[bin];
                 tile_lut[bin] = (sum as f64 * lut_scale).round().clamp(0.0, 255.0) as u8;
+            }
+        };
+
+        #[cfg(feature = "parallel")]
+        {
+            lut.par_chunks_mut(hist_size)
+                .enumerate()
+                .for_each(|(tile_idx, tile_lut)| {
+                    build_tile_lut(tile_idx, tile_lut);
+                });
+        }
+
+        #[cfg(not(feature = "parallel"))]
+        {
+            for (tile_idx, tile_lut) in lut.chunks_mut(hist_size).enumerate() {
+                build_tile_lut(tile_idx, tile_lut);
             }
         }
 
@@ -980,7 +1060,7 @@ impl Clahe {
         };
         let mut lut = vec![0u16; lut_len];
 
-        for tile_idx in 0..num_tiles {
+        let build_tile_lut = |tile_idx: usize, tile_lut: &mut [u16]| {
             let ty = tile_idx / self.tiles_x;
             let tx = tile_idx % self.tiles_x;
             let y0 = ty * tile_rows;
@@ -999,11 +1079,26 @@ impl Clahe {
 
             clip_and_redistribute(&mut tile_hist, clip_limit, hist_size);
 
-            let tile_lut = &mut lut[tile_idx * hist_size..(tile_idx + 1) * hist_size];
             let mut sum = 0i32;
             for bin in 0..hist_size {
                 sum += tile_hist[bin];
                 tile_lut[bin] = (sum as f64 * lut_scale).round().clamp(0.0, 65535.0) as u16;
+            }
+        };
+
+        #[cfg(feature = "parallel")]
+        {
+            lut.par_chunks_mut(hist_size)
+                .enumerate()
+                .for_each(|(tile_idx, tile_lut)| {
+                    build_tile_lut(tile_idx, tile_lut);
+                });
+        }
+
+        #[cfg(not(feature = "parallel"))]
+        {
+            for (tile_idx, tile_lut) in lut.chunks_mut(hist_size).enumerate() {
+                build_tile_lut(tile_idx, tile_lut);
             }
         }
 
@@ -1072,8 +1167,9 @@ fn interpolate_tiles_u8(
     let inv_th = 1.0f64 / tile_rows as f64;
     let lut_idx =
         |ty: usize, tx: usize, bin: usize| ty * tiles_x * hist_size + tx * hist_size + bin;
+    let cols = src.cols;
 
-    for y in 0..src.rows {
+    let process_row = |y: usize, dst_row: &mut [u8]| {
         let tyf = y as f64 * inv_th - 0.5;
         let ty1 = (tyf.floor() as i32).max(0);
         let ty2 = (ty1 + 1).min(tiles_y as i32 - 1);
@@ -1082,7 +1178,7 @@ fn interpolate_tiles_u8(
         let ty1 = ty1 as usize;
         let ty2 = ty2 as usize;
 
-        for x in 0..src.cols {
+        for (x, out_pixel) in dst_row.iter_mut().enumerate() {
             let txf = x as f64 * inv_tw - 0.5;
             let tx1 = (txf.floor() as i32).max(0);
             let tx2 = (tx1 + 1).min(tiles_x as i32 - 1);
@@ -1100,8 +1196,24 @@ fn interpolate_tiles_u8(
             let v11 = lut[lut_idx(ty2, tx2, bin)] as f64;
 
             let val = (v00 * xa1 + v01 * xa) * ya1 + (v10 * xa1 + v11 * xa) * ya;
-            let out = (val.round() as u8) << bit_shift;
-            dst.set(y, x, 0, out);
+            *out_pixel = (val.round() as u8) << bit_shift;
+        }
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        dst.data
+            .par_chunks_mut(cols)
+            .enumerate()
+            .for_each(|(y, dst_row)| {
+                process_row(y, dst_row);
+            });
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    {
+        for (y, dst_row) in dst.data.chunks_mut(cols).enumerate() {
+            process_row(y, dst_row);
         }
     }
 }
@@ -1122,8 +1234,9 @@ fn interpolate_tiles_u16(
     let inv_th = 1.0f64 / tile_rows as f64;
     let lut_idx =
         |ty: usize, tx: usize, bin: usize| ty * tiles_x * hist_size + tx * hist_size + bin;
+    let cols = src.cols;
 
-    for y in 0..src.rows {
+    let process_row = |y: usize, dst_row: &mut [u16]| {
         let tyf = y as f64 * inv_th - 0.5;
         let ty1 = (tyf.floor() as i32).max(0);
         let ty2 = (ty1 + 1).min(tiles_y as i32 - 1);
@@ -1132,7 +1245,7 @@ fn interpolate_tiles_u16(
         let ty1 = ty1 as usize;
         let ty2 = ty2 as usize;
 
-        for x in 0..src.cols {
+        for (x, out_pixel) in dst_row.iter_mut().enumerate() {
             let txf = x as f64 * inv_tw - 0.5;
             let tx1 = (txf.floor() as i32).max(0);
             let tx2 = (tx1 + 1).min(tiles_x as i32 - 1);
@@ -1150,8 +1263,24 @@ fn interpolate_tiles_u16(
             let v11 = lut[lut_idx(ty2, tx2, bin)] as f64;
 
             let val = (v00 * xa1 + v01 * xa) * ya1 + (v10 * xa1 + v11 * xa) * ya;
-            let out = (val.round() as u16) << bit_shift;
-            dst.set(y, x, 0, out);
+            *out_pixel = (val.round() as u16) << bit_shift;
+        }
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        dst.data
+            .par_chunks_mut(cols)
+            .enumerate()
+            .for_each(|(y, dst_row)| {
+                process_row(y, dst_row);
+            });
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    {
+        for (y, dst_row) in dst.data.chunks_mut(cols).enumerate() {
+            process_row(y, dst_row);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #106. The histogram module (added in #99) had zero `parallel`/`simd`
feature gating, unlike the rest of `imgproc`. This adds Rayon-backed fast
paths behind the existing `#[cfg(feature = "parallel")]` convention, with
sequential fallbacks preserved for `no_std`/`parallel`-disabled builds:

- **`calc_hist`** — row-chunked fold/reduce: each row-chunk accumulates into
  its own partial histogram (`Vec<f32>` of size `total_bins`), partials are
  summed elementwise via `reduce`. Kept fully generic over `dims` since the
  sequential code never special-cased it.
- **`calc_back_project`** — row-chunked, same `par_chunks_mut` shape already
  used in `color.rs`.
- **`equalize_hist`** — the histogram/LUT build stays sequential (cheap,
  ≤256 bins either way); the final LUT-apply pass over every pixel is now a
  flat `par_iter_mut().zip(...)`.
- **`Clahe::apply_u8`/`apply_u16`** — per-tile histogram + LUT construction
  parallelized via `par_chunks_mut` over the flat `lut` buffer (tiles are
  independent by construction), and both `interpolate_tiles_u8`/`_u16`
  row-chunked the same way as `calc_back_project`.

Also adds `calc_hist`/`calc_back_project`/`equalize_hist`/`Clahe::apply_u8`
benchmarks to `benches/imgproc_bench.rs`. Per discussion on #106, I'm not
updating `benches/benchmark_results.md` in this PR — those numbers need to
come from the same reference machine as the existing table for the results
to be comparable; that's tracked as a separate follow-up.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo clippy --no-default-features -- -D warnings`
- [x] `cargo test --workspace` (default features, `parallel` on) — 337 lib
      tests + 40 doc-tests, all passing
- [x] `cargo test --lib histogram --no-default-features --features std`
      (sequential fallback) — same 29 histogram tests pass, identical results
      to the parallel path
- [x] `cargo build --no-default-features --target thumbv7em-none-eabihf`
      (bare-metal) still compiles
- [x] New bench functions compile (`cargo bench --no-run`) and run cleanly
