### PR TITLE
feat(wasm): expose histogram module bindings

### DIFF
--- a/benches/imgproc_bench.rs
+++ b/benches/imgproc_bench.rs
@@ -287,6 +287,7 @@ fn bench_imgproc(c: &mut Criterion) {
             calc_back_project(
                 black_box(&[&img_hist]),
                 &[0],
+                &[256],
                 &hist_for_backproj,
                 &hist_ranges,
                 1.0,

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -80,9 +80,19 @@ images.push(grayMat);
 const channels = [0];
 const histSize = [256];
 const ranges = [0.0, 256.0]; // [min, max] per channel
-const hist = calcHistUniform(images, channels, undefined, histSize, ranges, false);
+const hist = calcHistUniform(images, channels, undefined, histSize, ranges, false, undefined);
+
+// To accumulate onto a previous histogram, pass accumulate=true and the
+// existing histogram Mat as the last argument instead of undefined:
+// calcHistUniform(images, channels, undefined, histSize, ranges, true, hist);
 ```
 
 *Note:* `equalizeHist` and `Clahe.apply` currently support single-channel 8-bit images (`CV_8UC1`). Support for 16-bit images (`CV_16UC1`) is planned for a future release.
+
+*Note:* `calcBackProjectUniform`/`calcBackProjectNonUniform` take an explicit
+`histSize` argument (right after `channels`) describing the shape the
+histogram was built with — a flat histogram's bin count alone can't be
+unambiguously reconstructed into a multi-dimensional shape (e.g. 8 bins
+could be `[8]` or `[2, 4]`).
 
 Note: To interface between JavaScript Typed Arrays and `purecv-wasm`, please use the available getter functions (`.data()`) which directly retrieve a Float32Array or Uint8Array view into WASM memory.

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -58,8 +58,31 @@ Because WebAssembly runs linearly in memory and holds pointers to Rust `Vec` obj
 Right now we have covered a large majority of operations for `core` and `imgproc`, and have started on `calib3d` and `video`:
 
 - **Core**: Arithmetic (`add`, `subtract`, `multiply`, `absdiff` etc.), Structural (`hconcat`, `vconcat`, `flip`), Geometry, constants etc.
-- **ImgProc**: Filters (`blur`, `gaussian_blur`, `bilateral_filter`), Thresholding (`threshold`), Coloring (`cvt_color`), Edge Derivatives (`canny`, `sobel`, `laplacian`), Morphology (`erode`, `dilate`, `morphology_ex`, `get_structuring_element`), Pyramids (`pyr_down`, `pyr_up`, `build_pyramid`), Feature Detection (`good_features_to_track`, `corner_sub_pix`).
+- **ImgProc**: Filters (`blur`, `gaussian_blur`, `bilateral_filter`), Thresholding (`threshold`), Coloring (`cvt_color`), Edge Derivatives (`canny`, `sobel`, `laplacian`), Morphology (`erode`, `dilate`, `morphology_ex`, `get_structuring_element`), Pyramids (`pyr_down`, `pyr_up`, `build_pyramid`), Feature Detection (`good_features_to_track`, `corner_sub_pix`), Histograms (`calcHistUniform`, `calcHistNonUniform`, `calcBackProjectUniform`, `calcBackProjectNonUniform`, `compareHist`, `equalizeHist`, `Clahe`).
 - **Video**: Optical Flow (`calc_optical_flow_pyr_lk`).
 - **Calib3d**: Pose Estimation (`solve_pnp`, `solve_pnp_ransac`), Homography (`find_homography`), and geometry (`rodrigues`).
+
+### Histogram & Contrast Operations
+
+```javascript
+import { Mat, MatVector, calcHistUniform, equalizeHist, Clahe } from '@webarkit/purecv-wasm';
+
+// 1. Equalize Histogram (8-bit grayscale only)
+const eqMat = equalizeHist(grayMat);
+
+// 2. CLAHE (Contrast Limited Adaptive Histogram Equalization)
+const clahe = new Clahe(40.0, 8, 8);
+const enhancedMat = clahe.apply(grayMat);
+
+// 3. Dense Histogram with uniform bins
+const images = new MatVector();
+images.push(grayMat);
+const channels = [0];
+const histSize = [256];
+const ranges = [0.0, 256.0]; // [min, max] per channel
+const hist = calcHistUniform(images, channels, undefined, histSize, ranges, false);
+```
+
+*Note:* `equalizeHist` and `Clahe.apply` currently support single-channel 8-bit images (`CV_8UC1`). Support for 16-bit images (`CV_16UC1`) is planned for a future release.
 
 Note: To interface between JavaScript Typed Arrays and `purecv-wasm`, please use the available getter functions (`.data()`) which directly retrieve a Float32Array or Uint8Array view into WASM memory.

--- a/crates/wasm/pkg/README.md
+++ b/crates/wasm/pkg/README.md
@@ -58,8 +58,41 @@ Because WebAssembly runs linearly in memory and holds pointers to Rust `Vec` obj
 Right now we have covered a large majority of operations for `core` and `imgproc`, and have started on `calib3d` and `video`:
 
 - **Core**: Arithmetic (`add`, `subtract`, `multiply`, `absdiff` etc.), Structural (`hconcat`, `vconcat`, `flip`), Geometry, constants etc.
-- **ImgProc**: Filters (`blur`, `gaussian_blur`, `bilateral_filter`), Thresholding (`threshold`), Coloring (`cvt_color`), Edge Derivatives (`canny`, `sobel`, `laplacian`), Morphology (`erode`, `dilate`, `morphology_ex`, `get_structuring_element`), Pyramids (`pyr_down`, `pyr_up`, `build_pyramid`), Feature Detection (`good_features_to_track`, `corner_sub_pix`).
+- **ImgProc**: Filters (`blur`, `gaussian_blur`, `bilateral_filter`), Thresholding (`threshold`), Coloring (`cvt_color`), Edge Derivatives (`canny`, `sobel`, `laplacian`), Morphology (`erode`, `dilate`, `morphology_ex`, `get_structuring_element`), Pyramids (`pyr_down`, `pyr_up`, `build_pyramid`), Feature Detection (`good_features_to_track`, `corner_sub_pix`), Histograms (`calcHistUniform`, `calcHistNonUniform`, `calcBackProjectUniform`, `calcBackProjectNonUniform`, `compareHist`, `equalizeHist`, `Clahe`).
 - **Video**: Optical Flow (`calc_optical_flow_pyr_lk`).
 - **Calib3d**: Pose Estimation (`solve_pnp`, `solve_pnp_ransac`), Homography (`find_homography`), and geometry (`rodrigues`).
+
+### Histogram & Contrast Operations
+
+```javascript
+import { Mat, MatVector, calcHistUniform, equalizeHist, Clahe } from '@webarkit/purecv-wasm';
+
+// 1. Equalize Histogram (8-bit grayscale only)
+const eqMat = equalizeHist(grayMat);
+
+// 2. CLAHE (Contrast Limited Adaptive Histogram Equalization)
+const clahe = new Clahe(40.0, 8, 8);
+const enhancedMat = clahe.apply(grayMat);
+
+// 3. Dense Histogram with uniform bins
+const images = new MatVector();
+images.push(grayMat);
+const channels = [0];
+const histSize = [256];
+const ranges = [0.0, 256.0]; // [min, max] per channel
+const hist = calcHistUniform(images, channels, undefined, histSize, ranges, false, undefined);
+
+// To accumulate onto a previous histogram, pass accumulate=true and the
+// existing histogram Mat as the last argument instead of undefined:
+// calcHistUniform(images, channels, undefined, histSize, ranges, true, hist);
+```
+
+*Note:* `equalizeHist` and `Clahe.apply` currently support single-channel 8-bit images (`CV_8UC1`). Support for 16-bit images (`CV_16UC1`) is planned for a future release.
+
+*Note:* `calcBackProjectUniform`/`calcBackProjectNonUniform` take an explicit
+`histSize` argument (right after `channels`) describing the shape the
+histogram was built with — a flat histogram's bin count alone can't be
+unambiguously reconstructed into a multi-dimensional shape (e.g. 8 bins
+could be `[8]` or `[2, 4]`).
 
 Note: To interface between JavaScript Typed Arrays and `purecv-wasm`, please use the available getter functions (`.data()`) which directly retrieve a Float32Array or Uint8Array view into WASM memory.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -47,6 +47,7 @@ use purecv::imgproc::derivatives;
 use purecv::imgproc::edge;
 use purecv::imgproc::feature;
 use purecv::imgproc::filter;
+use purecv::imgproc::histogram::{self, Clahe as CoreClahe, HistCompMethods, RangeSpec};
 use purecv::imgproc::hough;
 use purecv::imgproc::morph::{self, MorphShapes, MorphTypes};
 use purecv::imgproc::pyramid;
@@ -2751,5 +2752,586 @@ impl ORB {
         .map_err(|_| JsError::new("Failed to set descriptors"))?;
 
         Ok(obj.into())
+    }
+}
+// ---------------------------------------------------------------------------
+//  MatVector - Collection of Mats
+// ---------------------------------------------------------------------------
+
+/// Managed vector of Mat objects exposed to JavaScript.
+///
+/// Mirrors the cv.MatVector class from OpenCV.js.
+#[wasm_bindgen(js_name = "MatVector")]
+pub struct MatVector {
+    pub(crate) inner: Vec<DynamicMatrix>,
+}
+
+#[wasm_bindgen(js_class = "MatVector")]
+impl MatVector {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    /// Adds a Mat to the vector (clones the underlying matrix).
+    pub fn push(&mut self, mat: &Mat) {
+        self.inner.push(mat.inner.clone());
+    }
+
+    /// Alias for push, matching OpenCV.js conventions.
+    #[wasm_bindgen(js_name = "push_back")]
+    pub fn push_back(&mut self, mat: &Mat) {
+        self.push(mat);
+    }
+
+    /// Returns the Mat at the given index, or an error if out of bounds.
+    pub fn get(&self, idx: usize) -> Result<Mat, JsError> {
+        self.inner
+            .get(idx)
+            .cloned()
+            .map(|inner| Mat { inner })
+            .ok_or_else(|| JsError::new("Index out of bounds"))
+    }
+
+    /// Returns the number of matrices in the vector.
+    pub fn size(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns the number of matrices in the vector.
+    pub fn length(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if the vector contains no matrices.
+    #[wasm_bindgen(js_name = "isEmpty")]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+impl Default for MatVector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  JS-side enum constants: Histogram comparison methods
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen(js_name = "HIST_CMP_CORREL")]
+pub fn hist_cmp_correl() -> i32 {
+    0
+}
+#[wasm_bindgen(js_name = "HIST_CMP_CHISQR")]
+pub fn hist_cmp_chisqr() -> i32 {
+    1
+}
+#[wasm_bindgen(js_name = "HIST_CMP_CHISQR_ALT")]
+pub fn hist_cmp_chisqr_alt() -> i32 {
+    2
+}
+#[wasm_bindgen(js_name = "HIST_CMP_INTERSECT")]
+pub fn hist_cmp_intersect() -> i32 {
+    3
+}
+#[wasm_bindgen(js_name = "HIST_CMP_BHATTACHARYYA")]
+pub fn hist_cmp_bhattacharyya() -> i32 {
+    4
+}
+#[wasm_bindgen(js_name = "HIST_CMP_KL_DIV")]
+pub fn hist_cmp_kl_div() -> i32 {
+    5
+}
+
+fn hist_comp_method_from_i32(m: i32) -> Result<HistCompMethods, JsError> {
+    match m {
+        0 => Ok(HistCompMethods::Correl),
+        1 => Ok(HistCompMethods::ChiSqr),
+        2 => Ok(HistCompMethods::ChiSqrAlt),
+        3 => Ok(HistCompMethods::Intersection),
+        4 => Ok(HistCompMethods::Bhattacharyya),
+        5 => Ok(HistCompMethods::KullbackLeibler),
+        _ => Err(JsError::new(&format!("Unknown hist comp method: {m}"))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Histogram operations
+// ---------------------------------------------------------------------------
+
+/// Computes a joint dense histogram for a set of images using uniform ranges.
+///
+/// * images     - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels   - List of channel indices across the images.
+/// * mask       - Optional single-channel u8 mask (CV_8UC1).
+/// * hist_size  - Array of bin counts for each histogram dimension.
+/// * ranges     - Flat array of [min_0, max_0, min_1, max_1, ...] per dimension.
+/// * ccumulate - If true, the histogram is not cleared at the beginning when allocating.
+#[wasm_bindgen(js_name = "calcHistUniform")]
+pub fn calc_hist_uniform(
+    images: &MatVector,
+    channels: &[usize],
+    mask: Option<Mat>,
+    hist_size: &[usize],
+    ranges: &[f32],
+    accumulate: bool,
+) -> Result<Mat, JsError> {
+    if images.inner.is_empty() {
+        return Err(JsError::new(
+            "calcHistUniform: images vector must not be empty",
+        ));
+    }
+
+    if ranges.len() != hist_size.len() * 2 {
+        return Err(JsError::new(
+            "ranges array must have 2 elements (min, max) per dimension",
+        ));
+    }
+
+    let mut specs = Vec::with_capacity(hist_size.len());
+    for i in 0..hist_size.len() {
+        specs.push(RangeSpec::Uniform(ranges[i * 2], ranges[i * 2 + 1]));
+    }
+
+    let mask_ref = match &mask {
+        Some(m) => Some(require_u8(m, "calcHistUniform (mask)")?),
+        None => None,
+    };
+
+    let first = &images.inner[0];
+    let hist = match first {
+        DynamicMatrix {
+            data: DynamicData::U8(_),
+        } => {
+            let mut u8_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_u8() {
+                    u8_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcHistUniform: all images must have consistent depth (u8)",
+                    ));
+                }
+            }
+            histogram::calc_hist(
+                &u8_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+            )
+            .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        DynamicMatrix {
+            data: DynamicData::F32(_),
+        } => {
+            let mut f32_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_f32() {
+                    f32_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcHistUniform: all images must have consistent depth (f32)",
+                    ));
+                }
+            }
+            histogram::calc_hist(
+                &f32_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+            )
+            .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        _ => {
+            return Err(JsError::new(
+                "calcHistUniform: unsupported image depth (must be u8 or f32)",
+            ));
+        }
+    };
+
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(hist),
+        },
+    })
+}
+
+/// Computes a joint dense histogram for a set of images using non-uniform ranges.
+///
+/// * images     - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels   - List of channel indices across the images.
+/// * mask       - Optional single-channel u8 mask (CV_8UC1).
+/// * hist_size  - Array of bin counts for each histogram dimension.
+/// * ranges     - Array of Float32Arrays, one per dimension, containing bin boundary coordinates.
+/// * ccumulate - If true, the histogram is not cleared at the beginning.
+#[wasm_bindgen(js_name = "calcHistNonUniform")]
+pub fn calc_hist_non_uniform(
+    images: &MatVector,
+    channels: &[usize],
+    mask: Option<Mat>,
+    hist_size: &[usize],
+    ranges: js_sys::Array,
+    accumulate: bool,
+) -> Result<Mat, JsError> {
+    if images.inner.is_empty() {
+        return Err(JsError::new(
+            "calcHistNonUniform: images vector must not be empty",
+        ));
+    }
+
+    if ranges.length() as usize != hist_size.len() {
+        return Err(JsError::new(
+            "ranges array must have one Float32Array per dimension",
+        ));
+    }
+
+    let mut specs = Vec::with_capacity(hist_size.len());
+    for i in 0..hist_size.len() {
+        let js_val = ranges.get(i as u32);
+        let f32_array = js_sys::Float32Array::from(js_val);
+        let mut vec = vec![0.0f32; f32_array.length() as usize];
+        f32_array.copy_to(&mut vec);
+        specs.push(RangeSpec::NonUniform(vec));
+    }
+
+    let mask_ref = match &mask {
+        Some(m) => Some(require_u8(m, "calcHistNonUniform (mask)")?),
+        None => None,
+    };
+
+    let first = &images.inner[0];
+    let hist = match first {
+        DynamicMatrix {
+            data: DynamicData::U8(_),
+        } => {
+            let mut u8_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_u8() {
+                    u8_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcHistNonUniform: all images must have consistent depth (u8)",
+                    ));
+                }
+            }
+            histogram::calc_hist(
+                &u8_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+            )
+            .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        DynamicMatrix {
+            data: DynamicData::F32(_),
+        } => {
+            let mut f32_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_f32() {
+                    f32_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcHistNonUniform: all images must have consistent depth (f32)",
+                    ));
+                }
+            }
+            histogram::calc_hist(
+                &f32_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+            )
+            .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        _ => {
+            return Err(JsError::new(
+                "calcHistNonUniform: unsupported image depth (must be u8 or f32)",
+            ));
+        }
+    };
+
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(hist),
+        },
+    })
+}
+
+/// Computes the back projection of a histogram using uniform ranges.
+///
+/// * images   - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels - Channel indices to back-project.
+/// * hist     - Input histogram Mat (CV_32FC1).
+/// * ranges   - Flat array of [min_0, max_0, min_1, max_1, ...] per dimension.
+/// * scale    - Optional scale factor for the output back projection image.
+#[wasm_bindgen(js_name = "calcBackProjectUniform")]
+pub fn calc_back_project_uniform(
+    images: &MatVector,
+    channels: &[usize],
+    hist: &Mat,
+    ranges: &[f32],
+    scale: f32,
+) -> Result<Mat, JsError> {
+    if images.inner.is_empty() {
+        return Err(JsError::new(
+            "calcBackProjectUniform: images vector must not be empty",
+        ));
+    }
+
+    let dims = channels.len();
+    if ranges.len() != dims * 2 {
+        return Err(JsError::new(
+            "ranges array must have 2 elements (min, max) per channel dimension",
+        ));
+    }
+
+    let mut specs = Vec::with_capacity(dims);
+    for i in 0..dims {
+        specs.push(RangeSpec::Uniform(ranges[i * 2], ranges[i * 2 + 1]));
+    }
+
+    let h = require_f32(hist, "calcBackProjectUniform (hist)")?;
+
+    let first = &images.inner[0];
+    let bp = match first {
+        DynamicMatrix {
+            data: DynamicData::U8(_),
+        } => {
+            let mut u8_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_u8() {
+                    u8_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcBackProjectUniform: all images must have consistent depth (u8)",
+                    ));
+                }
+            }
+            histogram::calc_back_project(&u8_mats, channels, h, &specs, scale)
+                .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        DynamicMatrix {
+            data: DynamicData::F32(_),
+        } => {
+            let mut f32_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_f32() {
+                    f32_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcBackProjectUniform: all images must have consistent depth (f32)",
+                    ));
+                }
+            }
+            histogram::calc_back_project(&f32_mats, channels, h, &specs, scale)
+                .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        _ => {
+            return Err(JsError::new(
+                "calcBackProjectUniform: unsupported image depth (must be u8 or f32)",
+            ));
+        }
+    };
+
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(bp),
+        },
+    })
+}
+
+/// Computes the back projection of a histogram using non-uniform ranges.
+///
+/// * images   - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels - Channel indices to back-project.
+/// * hist     - Input histogram Mat (CV_32FC1).
+/// * ranges   - Array of Float32Arrays containing bin boundaries.
+/// * scale    - Optional scale factor for the output back projection image.
+#[wasm_bindgen(js_name = "calcBackProjectNonUniform")]
+pub fn calc_back_project_non_uniform(
+    images: &MatVector,
+    channels: &[usize],
+    hist: &Mat,
+    ranges: js_sys::Array,
+    scale: f32,
+) -> Result<Mat, JsError> {
+    if images.inner.is_empty() {
+        return Err(JsError::new(
+            "calcBackProjectNonUniform: images vector must not be empty",
+        ));
+    }
+
+    let dims = channels.len();
+    if ranges.length() as usize != dims {
+        return Err(JsError::new(
+            "ranges array must have one Float32Array per channel dimension",
+        ));
+    }
+
+    let mut specs = Vec::with_capacity(dims);
+    for i in 0..dims {
+        let js_val = ranges.get(i as u32);
+        let f32_array = js_sys::Float32Array::from(js_val);
+        let mut vec = vec![0.0f32; f32_array.length() as usize];
+        f32_array.copy_to(&mut vec);
+        specs.push(RangeSpec::NonUniform(vec));
+    }
+
+    let h = require_f32(hist, "calcBackProjectNonUniform (hist)")?;
+
+    let first = &images.inner[0];
+    let bp = match first {
+        DynamicMatrix {
+            data: DynamicData::U8(_),
+        } => {
+            let mut u8_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_u8() {
+                    u8_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcBackProjectNonUniform: all images must have consistent depth (u8)",
+                    ));
+                }
+            }
+            histogram::calc_back_project(&u8_mats, channels, h, &specs, scale)
+                .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        DynamicMatrix {
+            data: DynamicData::F32(_),
+        } => {
+            let mut f32_mats = Vec::with_capacity(images.inner.len());
+            for dyn_mat in &images.inner {
+                if let Some(m) = dyn_mat.as_matrix_f32() {
+                    f32_mats.push(m);
+                } else {
+                    return Err(JsError::new(
+                        "calcBackProjectNonUniform: all images must have consistent depth (f32)",
+                    ));
+                }
+            }
+            histogram::calc_back_project(&f32_mats, channels, h, &specs, scale)
+                .map_err(|e| JsError::new(&format!("{e}")))?
+        }
+        _ => {
+            return Err(JsError::new(
+                "calcBackProjectNonUniform: unsupported image depth (must be u8 or f32)",
+            ));
+        }
+    };
+
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::F32(bp),
+        },
+    })
+}
+
+/// Compares two histograms using the specified comparison method.
+///
+/// * h1     - First input histogram (CV_32FC1).
+/// * h2     - Second input histogram of the same size as h1 (CV_32FC1).
+/// * method - Comparison method: HIST_CMP_CORREL, HIST_CMP_CHISQR, etc.
+#[wasm_bindgen(js_name = "compareHist")]
+pub fn compare_hist(h1: &Mat, h2: &Mat, method: i32) -> Result<f64, JsError> {
+    let m1 = require_f32(h1, "compareHist (h1)")?;
+    let m2 = require_f32(h2, "compareHist (h2)")?;
+    let meth = hist_comp_method_from_i32(method)?;
+
+    histogram::compare_hist(m1, m2, meth).map_err(|e| JsError::new(&format!("{e}")))
+}
+
+/// Equalizes the histogram of a grayscale image.
+///
+/// **Note:** Currently only 8-bit single-channel images (CV_8UC1) are supported.
+/// 16-bit (CV_16UC1) images are not yet supported.
+///
+/// * src - Input single-channel 8-bit image (CV_8UC1).
+#[wasm_bindgen(js_name = "equalizeHist")]
+pub fn equalize_hist(src: &Mat) -> Result<Mat, JsError> {
+    let m = require_u8(src, "equalizeHist")?;
+    let res = histogram::equalize_hist(m).map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(Mat {
+        inner: DynamicMatrix {
+            data: DynamicData::U8(res),
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+//  Clahe wrapper
+// ---------------------------------------------------------------------------
+
+/// Contrast Limited Adaptive Histogram Equalization.
+///
+/// Wraps OpenCV-style CLAHE.
+#[wasm_bindgen(js_name = "Clahe")]
+pub struct WasmClahe {
+    inner: CoreClahe,
+}
+
+#[wasm_bindgen(js_class = "Clahe")]
+impl WasmClahe {
+    /// Creates a new CLAHE instance with given clip limit and grid size.
+    ///
+    /// * clip_limit        - Threshold for contrast limiting (default in OpenCV is 40.0).
+    /// * 	ile_grid_width   - Number of tiles horizontally (e.g. 8).
+    /// * 	ile_grid_height  - Number of tiles vertically (e.g. 8).
+    #[wasm_bindgen(constructor)]
+    pub fn new(clip_limit: f64, tile_grid_width: i32, tile_grid_height: i32) -> Self {
+        let size = purecv::core::types::Size2i::new(tile_grid_width, tile_grid_height);
+        Self {
+            inner: histogram::create_clahe(clip_limit, size),
+        }
+    }
+
+    /// Applies CLAHE to the input grayscale image.
+    ///
+    /// **Note:** Currently only 8-bit single-channel images (CV_8UC1) are supported.
+    /// 16-bit (CV_16UC1) support is not yet exposed in WebAssembly.
+    pub fn apply(&self, src: &Mat) -> Result<Mat, JsError> {
+        let m = require_u8(src, "Clahe::apply")?;
+        let res = self
+            .inner
+            .apply_u8(m)
+            .map_err(|e| JsError::new(&format!("{e}")))?;
+        Ok(Mat {
+            inner: DynamicMatrix {
+                data: DynamicData::U8(res),
+            },
+        })
+    }
+
+    /// Gets the clip limit threshold.
+    #[wasm_bindgen(getter, js_name = "clipLimit")]
+    pub fn clip_limit(&self) -> f64 {
+        self.inner.get_clip_limit()
+    }
+
+    /// Sets the clip limit threshold.
+    #[wasm_bindgen(setter, js_name = "clipLimit")]
+    pub fn set_clip_limit(&mut self, limit: f64) {
+        self.inner.set_clip_limit(limit);
+    }
+
+    /// Gets the number of tile grid columns (width).
+    #[wasm_bindgen(getter, js_name = "tileGridWidth")]
+    pub fn tile_grid_width(&self) -> i32 {
+        self.inner.get_tiles_grid_size().width
+    }
+
+    /// Gets the number of tile grid rows (height).
+    #[wasm_bindgen(getter, js_name = "tileGridHeight")]
+    pub fn tile_grid_height(&self) -> i32 {
+        self.inner.get_tiles_grid_size().height
+    }
+
+    /// Sets the tile grid size (columns and rows).
+    #[wasm_bindgen(js_name = "setTilesGridSize")]
+    pub fn set_tiles_grid_size(&mut self, width: i32, height: i32) {
+        self.inner
+            .set_tiles_grid_size(purecv::core::types::Size2i::new(width, height));
+    }
+
+    /// Gets the bit shift parameter.
+    #[wasm_bindgen(getter, js_name = "bitShift")]
+    pub fn bit_shift(&self) -> i32 {
+        self.inner.get_bit_shift()
+    }
+
+    /// Sets the bit shift parameter.
+    #[wasm_bindgen(setter, js_name = "bitShift")]
+    pub fn set_bit_shift(&mut self, bit_shift: i32) {
+        self.inner.set_bit_shift(bit_shift);
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -2863,12 +2863,14 @@ fn hist_comp_method_from_i32(m: i32) -> Result<HistCompMethods, JsError> {
 
 /// Computes a joint dense histogram for a set of images using uniform ranges.
 ///
-/// * images     - MatVector of input images (u8 or f32 depth, all matching).
-/// * channels   - List of channel indices across the images.
-/// * mask       - Optional single-channel u8 mask (CV_8UC1).
-/// * hist_size  - Array of bin counts for each histogram dimension.
-/// * ranges     - Flat array of [min_0, max_0, min_1, max_1, ...] per dimension.
-/// * ccumulate - If true, the histogram is not cleared at the beginning when allocating.
+/// * images        - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels      - List of channel indices across the images.
+/// * mask          - Optional single-channel u8 mask (CV_8UC1).
+/// * hist_size     - Array of bin counts for each histogram dimension.
+/// * ranges        - Flat array of [min_0, max_0, min_1, max_1, ...] per dimension.
+/// * accumulate    - If true, adds to `existing_hist` instead of starting from zero.
+/// * existing_hist - The histogram to accumulate into when `accumulate` is true
+///   (CV_32FC1, same size as the output). Ignored when `accumulate` is false.
 #[wasm_bindgen(js_name = "calcHistUniform")]
 pub fn calc_hist_uniform(
     images: &MatVector,
@@ -2877,10 +2879,11 @@ pub fn calc_hist_uniform(
     hist_size: &[usize],
     ranges: &[f32],
     accumulate: bool,
+    existing_hist: Option<Mat>,
 ) -> Result<Mat, JsError> {
     if images.inner.is_empty() {
         return Err(JsError::new(
-            "calcHistUniform: images vector must not be empty",
+            "calc_hist_uniform: images vector must not be empty",
         ));
     }
 
@@ -2896,7 +2899,11 @@ pub fn calc_hist_uniform(
     }
 
     let mask_ref = match &mask {
-        Some(m) => Some(require_u8(m, "calcHistUniform (mask)")?),
+        Some(m) => Some(require_u8(m, "calc_hist_uniform (mask)")?),
+        None => None,
+    };
+    let existing_hist_ref = match &existing_hist {
+        Some(h) => Some(require_f32(h, "calc_hist_uniform (existing_hist)")?),
         None => None,
     };
 
@@ -2911,12 +2918,18 @@ pub fn calc_hist_uniform(
                     u8_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcHistUniform: all images must have consistent depth (u8)",
+                        "calc_hist_uniform: all images must have consistent depth (u8)",
                     ));
                 }
             }
             histogram::calc_hist(
-                &u8_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+                &u8_mats,
+                channels,
+                mask_ref,
+                hist_size,
+                &specs,
+                accumulate,
+                existing_hist_ref,
             )
             .map_err(|e| JsError::new(&format!("{e}")))?
         }
@@ -2929,18 +2942,24 @@ pub fn calc_hist_uniform(
                     f32_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcHistUniform: all images must have consistent depth (f32)",
+                        "calc_hist_uniform: all images must have consistent depth (f32)",
                     ));
                 }
             }
             histogram::calc_hist(
-                &f32_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+                &f32_mats,
+                channels,
+                mask_ref,
+                hist_size,
+                &specs,
+                accumulate,
+                existing_hist_ref,
             )
             .map_err(|e| JsError::new(&format!("{e}")))?
         }
         _ => {
             return Err(JsError::new(
-                "calcHistUniform: unsupported image depth (must be u8 or f32)",
+                "calc_hist_uniform: unsupported image depth (must be u8 or f32)",
             ));
         }
     };
@@ -2954,12 +2973,14 @@ pub fn calc_hist_uniform(
 
 /// Computes a joint dense histogram for a set of images using non-uniform ranges.
 ///
-/// * images     - MatVector of input images (u8 or f32 depth, all matching).
-/// * channels   - List of channel indices across the images.
-/// * mask       - Optional single-channel u8 mask (CV_8UC1).
-/// * hist_size  - Array of bin counts for each histogram dimension.
-/// * ranges     - Array of Float32Arrays, one per dimension, containing bin boundary coordinates.
-/// * ccumulate - If true, the histogram is not cleared at the beginning.
+/// * images        - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels      - List of channel indices across the images.
+/// * mask          - Optional single-channel u8 mask (CV_8UC1).
+/// * hist_size     - Array of bin counts for each histogram dimension.
+/// * ranges        - Array of Float32Arrays, one per dimension, containing bin boundary coordinates.
+/// * accumulate    - If true, adds to `existing_hist` instead of starting from zero.
+/// * existing_hist - The histogram to accumulate into when `accumulate` is true
+///   (CV_32FC1, same size as the output). Ignored when `accumulate` is false.
 #[wasm_bindgen(js_name = "calcHistNonUniform")]
 pub fn calc_hist_non_uniform(
     images: &MatVector,
@@ -2968,10 +2989,11 @@ pub fn calc_hist_non_uniform(
     hist_size: &[usize],
     ranges: js_sys::Array,
     accumulate: bool,
+    existing_hist: Option<Mat>,
 ) -> Result<Mat, JsError> {
     if images.inner.is_empty() {
         return Err(JsError::new(
-            "calcHistNonUniform: images vector must not be empty",
+            "calc_hist_non_uniform: images vector must not be empty",
         ));
     }
 
@@ -2991,7 +3013,11 @@ pub fn calc_hist_non_uniform(
     }
 
     let mask_ref = match &mask {
-        Some(m) => Some(require_u8(m, "calcHistNonUniform (mask)")?),
+        Some(m) => Some(require_u8(m, "calc_hist_non_uniform (mask)")?),
+        None => None,
+    };
+    let existing_hist_ref = match &existing_hist {
+        Some(h) => Some(require_f32(h, "calc_hist_non_uniform (existing_hist)")?),
         None => None,
     };
 
@@ -3006,12 +3032,18 @@ pub fn calc_hist_non_uniform(
                     u8_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcHistNonUniform: all images must have consistent depth (u8)",
+                        "calc_hist_non_uniform: all images must have consistent depth (u8)",
                     ));
                 }
             }
             histogram::calc_hist(
-                &u8_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+                &u8_mats,
+                channels,
+                mask_ref,
+                hist_size,
+                &specs,
+                accumulate,
+                existing_hist_ref,
             )
             .map_err(|e| JsError::new(&format!("{e}")))?
         }
@@ -3024,18 +3056,24 @@ pub fn calc_hist_non_uniform(
                     f32_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcHistNonUniform: all images must have consistent depth (f32)",
+                        "calc_hist_non_uniform: all images must have consistent depth (f32)",
                     ));
                 }
             }
             histogram::calc_hist(
-                &f32_mats, channels, mask_ref, hist_size, &specs, accumulate, None,
+                &f32_mats,
+                channels,
+                mask_ref,
+                hist_size,
+                &specs,
+                accumulate,
+                existing_hist_ref,
             )
             .map_err(|e| JsError::new(&format!("{e}")))?
         }
         _ => {
             return Err(JsError::new(
-                "calcHistNonUniform: unsupported image depth (must be u8 or f32)",
+                "calc_hist_non_uniform: unsupported image depth (must be u8 or f32)",
             ));
         }
     };
@@ -3049,22 +3087,26 @@ pub fn calc_hist_non_uniform(
 
 /// Computes the back projection of a histogram using uniform ranges.
 ///
-/// * images   - MatVector of input images (u8 or f32 depth, all matching).
-/// * channels - Channel indices to back-project.
-/// * hist     - Input histogram Mat (CV_32FC1).
-/// * ranges   - Flat array of [min_0, max_0, min_1, max_1, ...] per dimension.
-/// * scale    - Optional scale factor for the output back projection image.
+/// * images    - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels  - Channel indices to back-project.
+/// * hist_size - Number of bins per dimension, matching how `hist` was built.
+///   `hist`'s flat length alone cannot recover its shape (e.g. an 8-bin
+///   histogram could be `[8]` or `[2, 4]`), so it must be supplied explicitly.
+/// * hist      - Input histogram Mat (CV_32FC1).
+/// * ranges    - Flat array of [min_0, max_0, min_1, max_1, ...] per dimension.
+/// * scale     - Optional scale factor for the output back projection image.
 #[wasm_bindgen(js_name = "calcBackProjectUniform")]
 pub fn calc_back_project_uniform(
     images: &MatVector,
     channels: &[usize],
+    hist_size: &[usize],
     hist: &Mat,
     ranges: &[f32],
     scale: f32,
 ) -> Result<Mat, JsError> {
     if images.inner.is_empty() {
         return Err(JsError::new(
-            "calcBackProjectUniform: images vector must not be empty",
+            "calc_back_project_uniform: images vector must not be empty",
         ));
     }
 
@@ -3080,7 +3122,7 @@ pub fn calc_back_project_uniform(
         specs.push(RangeSpec::Uniform(ranges[i * 2], ranges[i * 2 + 1]));
     }
 
-    let h = require_f32(hist, "calcBackProjectUniform (hist)")?;
+    let h = require_f32(hist, "calc_back_project_uniform (hist)")?;
 
     let first = &images.inner[0];
     let bp = match first {
@@ -3093,11 +3135,11 @@ pub fn calc_back_project_uniform(
                     u8_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcBackProjectUniform: all images must have consistent depth (u8)",
+                        "calc_back_project_uniform: all images must have consistent depth (u8)",
                     ));
                 }
             }
-            histogram::calc_back_project(&u8_mats, channels, h, &specs, scale)
+            histogram::calc_back_project(&u8_mats, channels, hist_size, h, &specs, scale)
                 .map_err(|e| JsError::new(&format!("{e}")))?
         }
         DynamicMatrix {
@@ -3109,16 +3151,16 @@ pub fn calc_back_project_uniform(
                     f32_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcBackProjectUniform: all images must have consistent depth (f32)",
+                        "calc_back_project_uniform: all images must have consistent depth (f32)",
                     ));
                 }
             }
-            histogram::calc_back_project(&f32_mats, channels, h, &specs, scale)
+            histogram::calc_back_project(&f32_mats, channels, hist_size, h, &specs, scale)
                 .map_err(|e| JsError::new(&format!("{e}")))?
         }
         _ => {
             return Err(JsError::new(
-                "calcBackProjectUniform: unsupported image depth (must be u8 or f32)",
+                "calc_back_project_uniform: unsupported image depth (must be u8 or f32)",
             ));
         }
     };
@@ -3132,22 +3174,26 @@ pub fn calc_back_project_uniform(
 
 /// Computes the back projection of a histogram using non-uniform ranges.
 ///
-/// * images   - MatVector of input images (u8 or f32 depth, all matching).
-/// * channels - Channel indices to back-project.
-/// * hist     - Input histogram Mat (CV_32FC1).
-/// * ranges   - Array of Float32Arrays containing bin boundaries.
-/// * scale    - Optional scale factor for the output back projection image.
+/// * images    - MatVector of input images (u8 or f32 depth, all matching).
+/// * channels  - Channel indices to back-project.
+/// * hist_size - Number of bins per dimension, matching how `hist` was built.
+///   `hist`'s flat length alone cannot recover its shape (e.g. an 8-bin
+///   histogram could be `[8]` or `[2, 4]`), so it must be supplied explicitly.
+/// * hist      - Input histogram Mat (CV_32FC1).
+/// * ranges    - Array of Float32Arrays containing bin boundaries.
+/// * scale     - Optional scale factor for the output back projection image.
 #[wasm_bindgen(js_name = "calcBackProjectNonUniform")]
 pub fn calc_back_project_non_uniform(
     images: &MatVector,
     channels: &[usize],
+    hist_size: &[usize],
     hist: &Mat,
     ranges: js_sys::Array,
     scale: f32,
 ) -> Result<Mat, JsError> {
     if images.inner.is_empty() {
         return Err(JsError::new(
-            "calcBackProjectNonUniform: images vector must not be empty",
+            "calc_back_project_non_uniform: images vector must not be empty",
         ));
     }
 
@@ -3167,7 +3213,7 @@ pub fn calc_back_project_non_uniform(
         specs.push(RangeSpec::NonUniform(vec));
     }
 
-    let h = require_f32(hist, "calcBackProjectNonUniform (hist)")?;
+    let h = require_f32(hist, "calc_back_project_non_uniform (hist)")?;
 
     let first = &images.inner[0];
     let bp = match first {
@@ -3180,11 +3226,11 @@ pub fn calc_back_project_non_uniform(
                     u8_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcBackProjectNonUniform: all images must have consistent depth (u8)",
+                        "calc_back_project_non_uniform: all images must have consistent depth (u8)",
                     ));
                 }
             }
-            histogram::calc_back_project(&u8_mats, channels, h, &specs, scale)
+            histogram::calc_back_project(&u8_mats, channels, hist_size, h, &specs, scale)
                 .map_err(|e| JsError::new(&format!("{e}")))?
         }
         DynamicMatrix {
@@ -3196,16 +3242,16 @@ pub fn calc_back_project_non_uniform(
                     f32_mats.push(m);
                 } else {
                     return Err(JsError::new(
-                        "calcBackProjectNonUniform: all images must have consistent depth (f32)",
+                        "calc_back_project_non_uniform: all images must have consistent depth (f32)",
                     ));
                 }
             }
-            histogram::calc_back_project(&f32_mats, channels, h, &specs, scale)
+            histogram::calc_back_project(&f32_mats, channels, hist_size, h, &specs, scale)
                 .map_err(|e| JsError::new(&format!("{e}")))?
         }
         _ => {
             return Err(JsError::new(
-                "calcBackProjectNonUniform: unsupported image depth (must be u8 or f32)",
+                "calc_back_project_non_uniform: unsupported image depth (must be u8 or f32)",
             ));
         }
     };
@@ -3265,8 +3311,8 @@ impl WasmClahe {
     /// Creates a new CLAHE instance with given clip limit and grid size.
     ///
     /// * clip_limit        - Threshold for contrast limiting (default in OpenCV is 40.0).
-    /// * 	ile_grid_width   - Number of tiles horizontally (e.g. 8).
-    /// * 	ile_grid_height  - Number of tiles vertically (e.g. 8).
+    /// * tile_grid_width   - Number of tiles horizontally (e.g. 8).
+    /// * tile_grid_height  - Number of tiles vertically (e.g. 8).
     #[wasm_bindgen(constructor)]
     pub fn new(clip_limit: f64, tile_grid_width: i32, tile_grid_height: i32) -> Self {
         let size = purecv::core::types::Size2i::new(tile_grid_width, tile_grid_height);

--- a/crates/wasm/tests/web.rs
+++ b/crates/wasm/tests/web.rs
@@ -1,7 +1,8 @@
 #![cfg(target_arch = "wasm32")]
 
 use purecv_wasm::{
-    find_homography_wasm, rodrigues_wasm, solve_pnp_wasm, Mat, Point2fVector, Point3fVector,
+    calc_hist_uniform, compare_hist, equalize_hist, find_homography_wasm, hist_cmp_correl,
+    rodrigues_wasm, solve_pnp_wasm, Clahe, Mat, MatVector, Point2fVector, Point3fVector,
 };
 use wasm_bindgen_test::*;
 
@@ -119,4 +120,45 @@ fn test_find_homography() {
         3.0,
     )
     .unwrap();
+}
+
+#[wasm_bindgen_test]
+fn test_equalize_hist() {
+    let data = vec![0, 50, 100, 150, 200, 255];
+    let src = Mat::from_u8_data(2, 3, 1, &data).unwrap();
+    let eq = equalize_hist(&src).unwrap();
+    assert_eq!(eq.rows(), 2);
+    assert_eq!(eq.cols(), 3);
+}
+
+#[wasm_bindgen_test]
+fn test_clahe() {
+    let data = vec![128u8; 64];
+    let src = Mat::from_u8_data(8, 8, 1, &data).unwrap();
+    let mut clahe = Clahe::new(40.0, 8, 8);
+    assert_eq!(clahe.clip_limit(), 40.0);
+    clahe.set_clip_limit(20.0);
+    assert_eq!(clahe.clip_limit(), 20.0);
+    let dst = clahe.apply(&src).unwrap();
+    assert_eq!(dst.rows(), 8);
+    assert_eq!(dst.cols(), 8);
+}
+
+#[wasm_bindgen_test]
+fn test_calc_hist_and_compare() {
+    let mut mv = MatVector::new();
+    let data = vec![0u8, 1, 2, 3, 4, 5, 6, 7];
+    let img = Mat::from_u8_data(2, 4, 1, &data).unwrap();
+    mv.push(&img);
+    assert_eq!(mv.length(), 1);
+
+    let hist_size = vec![4];
+    let ranges = vec![0.0, 8.0];
+    let channels = vec![0];
+    let h1 = calc_hist_uniform(&mv, &channels, None, &hist_size, &ranges, false).unwrap();
+    assert_eq!(h1.rows(), 4);
+    assert_eq!(h1.cols(), 1);
+
+    let score = compare_hist(&h1, &h1, hist_cmp_correl()).unwrap();
+    assert!((score - 1.0).abs() < 1e-4);
 }

--- a/crates/wasm/tests/web.rs
+++ b/crates/wasm/tests/web.rs
@@ -1,8 +1,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use purecv_wasm::{
-    calc_hist_uniform, compare_hist, equalize_hist, find_homography_wasm, hist_cmp_correl,
-    rodrigues_wasm, solve_pnp_wasm, Clahe, Mat, MatVector, Point2fVector, Point3fVector,
+    calc_back_project_uniform, calc_hist_uniform, compare_hist, equalize_hist,
+    find_homography_wasm, hist_cmp_correl, rodrigues_wasm, solve_pnp_wasm, Mat, MatVector,
+    Point2fVector, Point3fVector, WasmClahe,
 };
 use wasm_bindgen_test::*;
 
@@ -135,7 +136,7 @@ fn test_equalize_hist() {
 fn test_clahe() {
     let data = vec![128u8; 64];
     let src = Mat::from_u8_data(8, 8, 1, &data).unwrap();
-    let mut clahe = Clahe::new(40.0, 8, 8);
+    let mut clahe = WasmClahe::new(40.0, 8, 8);
     assert_eq!(clahe.clip_limit(), 40.0);
     clahe.set_clip_limit(20.0);
     assert_eq!(clahe.clip_limit(), 20.0);
@@ -155,10 +156,57 @@ fn test_calc_hist_and_compare() {
     let hist_size = vec![4];
     let ranges = vec![0.0, 8.0];
     let channels = vec![0];
-    let h1 = calc_hist_uniform(&mv, &channels, None, &hist_size, &ranges, false).unwrap();
+    let h1 = calc_hist_uniform(&mv, &channels, None, &hist_size, &ranges, false, None).unwrap();
     assert_eq!(h1.rows(), 4);
     assert_eq!(h1.cols(), 1);
 
     let score = compare_hist(&h1, &h1, hist_cmp_correl()).unwrap();
     assert!((score - 1.0).abs() < 1e-4);
+
+    // 8 pixel values (0..8) into 4 bins over [0,8) -> 2 pixels per bin.
+    assert_eq!(h1.data_f32().unwrap(), vec![2.0, 2.0, 2.0, 2.0]);
+
+    // accumulate=true should add onto existing_hist, not start from zero.
+    let h2 = calc_hist_uniform(&mv, &channels, None, &hist_size, &ranges, true, Some(h1)).unwrap();
+    assert_eq!(h2.data_f32().unwrap(), vec![4.0, 4.0, 4.0, 4.0]);
+}
+
+#[wasm_bindgen_test]
+fn test_calc_back_project_2d_shape() {
+    // Regression test: calc_back_project_uniform now requires an explicit
+    // hist_size, so the flat 8-bin histogram below is correctly treated as
+    // a [2, 4] shape rather than guessed (and previously miscomputed as
+    // [1, 8]) from its bin count alone.
+    let mut mv = MatVector::new();
+    let img = Mat::from_u8_data(1, 1, 2, &[1u8, 7]).unwrap();
+    mv.push(&img);
+
+    let hist_data: Vec<f32> = vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0];
+    let hist = Mat::from_f32_data(8, 1, 1, &hist_data).unwrap();
+
+    let bp = calc_back_project_uniform(&mv, &[0, 1], &[2, 4], &hist, &[0.0, 2.0, 0.0, 8.0], 1.0)
+        .unwrap();
+    // channel 0 (value 1, range [0,2), 2 bins) -> bin 1
+    // channel 1 (value 7, range [0,8), 4 bins)  -> bin 3
+    // flat index with strides [4, 1] -> 1*4 + 3 = 7 -> hist.data[7] = 80.0
+    assert_eq!(bp.data_f32().unwrap(), vec![80.0]);
+}
+
+#[wasm_bindgen_test]
+fn test_calc_back_project_mismatched_image_size_error() {
+    let mut mv = MatVector::new();
+    mv.push(&Mat::from_u8_data(2, 2, 1, &[0u8, 1, 2, 3]).unwrap());
+    mv.push(&Mat::from_u8_data(3, 3, 1, &[0u8; 9]).unwrap());
+
+    let hist = Mat::from_f32_data(4, 1, 1, &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    assert!(calc_back_project_uniform(&mv, &[0, 1], &[4], &hist, &[0.0, 4.0], 1.0).is_err());
+}
+
+#[wasm_bindgen_test]
+fn test_calc_hist_multichannel_mask_error() {
+    let mut mv = MatVector::new();
+    mv.push(&Mat::from_u8_data(2, 2, 1, &[0u8, 1, 2, 3]).unwrap());
+
+    let mask = Mat::from_u8_data(2, 2, 3, &[1u8; 12]).unwrap();
+    assert!(calc_hist_uniform(&mv, &[0], Some(mask), &[4], &[0.0, 4.0], false, None).is_err());
 }

--- a/src/imgproc/histogram.rs
+++ b/src/imgproc/histogram.rs
@@ -253,6 +253,14 @@ pub fn calc_hist<T: ToPrimitive + Clone + Default + Send + Sync>(
                 "calc_hist: mask must have the same size as images"
             );
         }
+        if m.channels != 1 {
+            cv_bail!(
+                tags::IMGPROC,
+                InvalidInput,
+                "calc_hist: mask must be single-channel (got {})",
+                m.channels
+            );
+        }
     }
 
     // Validate channel indices
@@ -418,7 +426,11 @@ pub fn calc_hist<T: ToPrimitive + Clone + Default + Send + Sync>(
 ///
 /// * `images` - Slice of input images.
 /// * `channels` - Global channel indices (same semantics as `calc_hist`).
-/// * `hist` - Input histogram (`f32`, flattened multi-dimensional).
+/// * `hist_size` - Number of bins per dimension, matching how `hist` was built
+///   by `calc_hist`. `hist`'s flattened bin count alone cannot recover this
+///   shape unambiguously (e.g. 8 bins could be `[8]`, `[2, 4]`, `[4, 2]`, ...),
+///   so it must be supplied explicitly rather than guessed.
+/// * `hist` - Input histogram (`f32`, flattened multi-dimensional, size `product(hist_size)`).
 /// * `ranges` - One `RangeSpec` per dimension.
 /// * `scale` - Scale factor for the output values.
 ///
@@ -427,6 +439,7 @@ pub fn calc_hist<T: ToPrimitive + Clone + Default + Send + Sync>(
 pub fn calc_back_project<T: ToPrimitive + Clone + Default + Send + Sync>(
     images: &[&Matrix<T>],
     channels: &[usize],
+    hist_size: &[usize],
     hist: &Matrix<f32>,
     ranges: &[RangeSpec],
     scale: f32,
@@ -455,19 +468,52 @@ pub fn calc_back_project<T: ToPrimitive + Clone + Default + Send + Sync>(
             dims
         );
     }
+    if hist_size.len() != dims {
+        cv_bail!(
+            tags::IMGPROC,
+            InvalidInput,
+            "calc_back_project: hist_size length ({}) must match channels length ({})",
+            hist_size.len(),
+            dims
+        );
+    }
 
     let rows = images[0].rows;
     let cols = images[0].cols;
 
-    let total_bins = hist.rows * hist.cols * hist.channels;
+    for img in images.iter() {
+        if img.rows != rows || img.cols != cols {
+            cv_bail!(
+                tags::IMGPROC,
+                InvalidInput,
+                "calc_back_project: all images must have the same size"
+            );
+        }
+    }
+
+    // Validate channel indices
+    for &ch in channels {
+        let _ = resolve_channel(ch, images)?;
+    }
+
+    let total_bins: usize = hist_size.iter().product();
     if total_bins == 0 {
         cv_bail!(
             tags::IMGPROC,
             InvalidInput,
-            "calc_back_project: hist must not be empty"
+            "calc_back_project: hist_size must not contain a zero dimension"
         );
     }
-    let hist_size = infer_hist_size(total_bins, dims);
+    let hist_len = hist.rows * hist.cols * hist.channels;
+    if hist_len != total_bins {
+        cv_bail!(
+            tags::IMGPROC,
+            InvalidInput,
+            "calc_back_project: hist length {} does not match product(hist_size) {}",
+            hist_len,
+            total_bins
+        );
+    }
 
     let mut strides = vec![1usize; dims];
     for i in (0..dims - 1).rev() {
@@ -524,19 +570,6 @@ pub fn calc_back_project<T: ToPrimitive + Clone + Default + Send + Sync>(
     }
 
     Ok(dst)
-}
-
-fn infer_hist_size(total_bins: usize, dims: usize) -> Vec<usize> {
-    if dims == 1 {
-        return vec![total_bins];
-    }
-    let approx = (total_bins as f64).powf(1.0 / dims as f64).round() as usize;
-    if approx.pow(dims as u32) == total_bins {
-        return vec![approx; dims];
-    }
-    let mut sizes = vec![1usize; dims];
-    sizes[dims - 1] = total_bins;
-    sizes
 }
 
 // ---------------------------------------------------------------------------
@@ -1419,6 +1452,25 @@ mod tests {
     }
 
     #[test]
+    fn test_calc_hist_multichannel_mask_error() {
+        // Regression test: a mask must be single-channel. Previously only
+        // rows/cols were checked, so a multichannel mask was silently
+        // accepted and only its channel 0 was ever read.
+        let img = Matrix::from_vec(2, 2, 1, vec![0u8, 1, 2, 3]);
+        let mask = Matrix::from_vec(2, 2, 3, vec![1u8; 12]);
+        assert!(calc_hist(
+            &[&img],
+            &[0],
+            Some(&mask),
+            &[4],
+            &[RangeSpec::Uniform(0.0, 4.0)],
+            false,
+            None,
+        )
+        .is_err());
+    }
+
+    #[test]
     fn test_calc_hist_multi_image_channel_indexing() {
         // images[0] has 2 channels, images[1] has 1 channel
         let img0 = Matrix::from_vec(2, 1, 2, vec![10, 20, 30, 40]);
@@ -1470,12 +1522,63 @@ mod tests {
         let data: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7];
         let img = Matrix::from_vec(2, 4, 1, data);
         let hist = Matrix::from_vec(4, 1, 1, vec![10.0, 20.0, 30.0, 40.0]);
-        let bp =
-            calc_back_project(&[&img], &[0], &hist, &[RangeSpec::Uniform(0.0, 8.0)], 1.0).unwrap();
+        let bp = calc_back_project(
+            &[&img],
+            &[0],
+            &[4],
+            &hist,
+            &[RangeSpec::Uniform(0.0, 8.0)],
+            1.0,
+        )
+        .unwrap();
         assert_eq!(
             bp.data,
             vec![10.0, 10.0, 20.0, 20.0, 30.0, 30.0, 40.0, 40.0]
         );
+    }
+
+    #[test]
+    fn test_calc_back_project_2d_shape() {
+        // Regression test: without an explicit hist_size, a flat 8-bin
+        // histogram used to have its shape *guessed* from its length alone
+        // (infer_hist_size), which silently produced the wrong shape for any
+        // non-perfect-power dims (e.g. [2, 4] was inferred as [1, 8]) and
+        // corrupted the bin math. hist_size is now required explicitly.
+        let img = Matrix::from_vec(1, 1, 2, vec![1u8, 7]);
+        let hist = Matrix::from_vec(
+            8,
+            1,
+            1,
+            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0],
+        );
+        let bp = calc_back_project(
+            &[&img],
+            &[0, 1],
+            &[2, 4],
+            &hist,
+            &[RangeSpec::Uniform(0.0, 2.0), RangeSpec::Uniform(0.0, 8.0)],
+            1.0,
+        )
+        .unwrap();
+        // channel 0 (value 1, range [0,2), 2 bins) -> bin 1
+        // channel 1 (value 7, range [0,8), 4 bins)  -> bin 3
+        // flat index with strides [4, 1] -> 1*4 + 3 = 7 -> hist.data[7] = 80.0
+        assert_eq!(bp.data, vec![80.0]);
+    }
+
+    #[test]
+    fn test_calc_back_project_hist_size_mismatch_error() {
+        let img = Matrix::from_vec(1, 4, 1, vec![0u8, 1, 2, 3]);
+        let hist = Matrix::from_vec(4, 1, 1, vec![10.0, 20.0, 30.0, 40.0]);
+        assert!(calc_back_project(
+            &[&img],
+            &[0],
+            &[3], // doesn't match hist's 4 bins
+            &hist,
+            &[RangeSpec::Uniform(0.0, 4.0)],
+            1.0,
+        )
+        .is_err());
     }
 
     #[test]
@@ -1630,10 +1733,15 @@ mod tests {
     fn test_calc_back_project_empty_channels_error() {
         let img = Matrix::from_vec(2, 2, 1, vec![0u8; 4]);
         let hist = Matrix::from_vec(4, 1, 1, vec![0.0; 4]);
-        assert!(
-            calc_back_project::<u8>(&[&img], &[], &hist, &[RangeSpec::Uniform(0.0, 4.0)], 1.0,)
-                .is_err()
-        );
+        assert!(calc_back_project::<u8>(
+            &[&img],
+            &[],
+            &[],
+            &hist,
+            &[RangeSpec::Uniform(0.0, 4.0)],
+            1.0,
+        )
+        .is_err());
     }
 
     #[test]
@@ -1643,8 +1751,15 @@ mod tests {
         // reach the row-chunking dispatch.
         let img = Matrix::<u8>::from_vec(3, 0, 1, vec![]);
         let hist = Matrix::from_vec(4, 1, 1, vec![0.0; 4]);
-        let dst =
-            calc_back_project(&[&img], &[0], &hist, &[RangeSpec::Uniform(0.0, 4.0)], 1.0).unwrap();
+        let dst = calc_back_project(
+            &[&img],
+            &[0],
+            &[4],
+            &hist,
+            &[RangeSpec::Uniform(0.0, 4.0)],
+            1.0,
+        )
+        .unwrap();
         assert_eq!(dst.rows, 3);
         assert_eq!(dst.cols, 0);
         assert_eq!(dst.data.len(), 0);
@@ -1787,8 +1902,15 @@ mod tests {
     fn test_calc_back_project_scale() {
         let img = Matrix::from_vec(1, 4, 1, vec![0u8, 1, 2, 3]);
         let hist = Matrix::from_vec(4, 1, 1, vec![10.0, 20.0, 30.0, 40.0]);
-        let bp =
-            calc_back_project(&[&img], &[0], &hist, &[RangeSpec::Uniform(0.0, 4.0)], 2.0).unwrap();
+        let bp = calc_back_project(
+            &[&img],
+            &[0],
+            &[4],
+            &hist,
+            &[RangeSpec::Uniform(0.0, 4.0)],
+            2.0,
+        )
+        .unwrap();
         assert_eq!(bp.data, vec![20.0, 40.0, 60.0, 80.0]);
     }
 
@@ -1827,10 +1949,15 @@ mod tests {
         )
         .is_err());
         let hist = Matrix::from_vec(4, 1, 1, vec![0.0; 4]);
-        assert!(
-            calc_back_project::<u8>(&[&img], &[], &hist, &[RangeSpec::Uniform(0.0, 4.0)], 1.0,)
-                .is_err()
-        );
+        assert!(calc_back_project::<u8>(
+            &[&img],
+            &[],
+            &[],
+            &hist,
+            &[RangeSpec::Uniform(0.0, 4.0)],
+            1.0,
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Expose WebAssembly bindings for PureCV's histogram module.

### Motivation
crates/wasm/src/lib.rs provides Mat-based bindings for core operations, color conversion, edge detection, filtering, feature matching, and calib3d, but none of the algorithms from src/imgproc/histogram.rs. This PR exposes histogram computation, back projection, comparison metrics, histogram equalization, and CLAHE to @webarkit/purecv-wasm.

### Changes
- Added an OpenCV.js-compatible MatVector class to safely pass image collections across the WASM boundary.
- Added calcHistUniform and calcHistNonUniform entry points with support for both u8 and 32 input matrices, masks, and accumulation.
- Added calcBackProjectUniform and calcBackProjectNonUniform.
- Exported HIST_CMP_* constants (CORREL, CHISQR, CHISQR_ALT, INTERSECT, BHATTACHARYYA, KL_DIV) and compareHist(h1, h2, method).
- Added equalizeHist(src) with notes clarifying that it currently operates on single-channel 8-bit images (CV_8UC1).
- Added Clahe wrapper class (
ew, pply, clipLimit, 	ileGridWidth, 	ileGridHeight, setTilesGridSize, itShift), noting 8-bit single-channel support.
- Added integration tests in crates/wasm/tests/web.rs and updated crates/wasm/README.md.

Fixes #107