### PR TITLE
doc: add histogram/CLAHE examples (Rust + WASM) and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Unlike existing wrappers, **PureCV** is a native rewrite. It aims to provide:
 - **Hough Transform:** Standard (`hough_lines`) and Probabilistic (`hough_lines_p`) line detection, plus Hough Circle Transform (`hough_circles`) using internally computed Sobel gradients. Fully parallelized via the `parallel` feature.
 - **Resizing:** `resize` function utilizing high-performance bilinear interpolation, fully compatible with `parallel` Rayon multi-threading.
 - **Geometric Transformations:** `remap` (with bilinear and nearest-neighbor interpolation) and `warp_perspective` (perspective transformations) fully parallelized and SIMD-accelerated.
+- **Histograms & Contrast:** `calc_hist` (multi-dimensional, uniform or non-uniform bins, optional mask and accumulation) and `calc_back_project` for histogram back-projection; `compare_hist` with all 6 OpenCV comparison methods (`Correl`, `ChiSqr`, `ChiSqrAlt`, `Intersection`, `Bhattacharyya`, `KullbackLeibler`), SIMD-accelerated via the `simd` feature; `equalize_hist` for global histogram equalization; and `Clahe` (Contrast Limited Adaptive Histogram Equalization) for `u8`/`u16` images. `calc_hist`, `calc_back_project`, `equalize_hist`, and `Clahe` are all parallelized via the `parallel` feature.
 
 ### `purecv-features2d`
 - **FAST Feature Detector:** Real-time corner detector (`FastFeatureDetector`) supporting Type 5_8, 7_12, and 9_16 neighborhood configurations, plus optional non-maximum suppression.
@@ -312,6 +313,9 @@ cargo run --example morphology
 # Gaussian pyramids (pyr_down, pyr_up)
 cargo run --example pyramids
 
+# Histograms & contrast (calc_hist, calc_back_project, compare_hist, equalize_hist, CLAHE)
+cargo run --example histogram
+
 # Hough Transform (Lines and Circles detection)
 cargo run --example hough_transform
 
@@ -344,10 +348,10 @@ cargo run --example rectification
 ## 🧪 Testing & Benchmarking
 
 ### Running Tests
-PureCV uses a comprehensive suite of unit tests to ensure correctness and parity with OpenCV. The test suite currently includes **308 unit tests** (plus **40 doc-tests**) covering:
+PureCV uses a comprehensive suite of unit tests to ensure correctness and parity with OpenCV. The test suite currently includes **342 unit tests** (plus **40 doc-tests**) covering:
 
 - **Core module:** Matrix factories, scalar arithmetic variants, bitwise scalar ops, min/max, comparison ops (`compare`, `in_range`), reduction (`reduce`, `count_non_zero`), polar/cartesian conversions, linear algebra (`determinant`, `invert`, `solve`), channel ops (`extract_channel`, `insert_channel`), `DynamicMatrix`, transforms, sorting, clustering, and RNG.
-- **Imgproc module:** Filters, derivatives, edge detection, color conversions (including gray-to-RGB/BGR/RGBA/BGRA), thresholding, morphology (`erode`, `dilate`), pyramids (`pyr_down`, `pyr_up`), and kernel helpers (`get_gaussian_kernel`, `get_sobel_kernels`).
+- **Imgproc module:** Filters, derivatives, edge detection, color conversions (including gray-to-RGB/BGR/RGBA/BGRA), thresholding, morphology (`erode`, `dilate`), pyramids (`pyr_down`, `pyr_up`), kernel helpers (`get_gaussian_kernel`, `get_sobel_kernels`), and histograms/CLAHE (`calc_hist`, `calc_back_project`, `compare_hist`, `equalize_hist`, `Clahe`).
 - **Features2d module:** Keypoint structures (`KeyPoint`), FAST corner detection (`FastFeatureDetector`), scale pyramids, and ORB feature extraction & BRIEF descriptor extraction (`Orb`).
 - **Video module:** Tracking and optical flow capabilities including `calc_optical_flow_pyr_lk` and `build_optical_flow_pyramid` implementations.
 - **Calib3d module:** SVD, homography estimation, pose estimation (`solve_pnp`), and `rodrigues`.

--- a/crates/wasm/www/example_histogram.html
+++ b/crates/wasm/www/example_histogram.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<!--
+ *  example_histogram.html
+ *  purecv
+ *
+ *  This file is part of purecv - WebARKit.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PureCV - Histogram & CLAHE</title>
+    <style>
+        :root {
+            --primary: #43e97b;
+            --secondary: #38f9d7;
+            --bg: #0f172a;
+            --card: #1e293b;
+            --text: #f8fafc;
+        }
+        body {
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            background-color: var(--bg);
+            color: var(--text);
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 1000px;
+            width: 90%;
+            margin: 2rem 0;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+        .header h1 {
+            font-size: 2.5rem;
+            background: linear-gradient(to right, var(--primary), var(--secondary));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            margin-bottom: 0.5rem;
+        }
+        .card {
+            background: var(--card);
+            border-radius: 1rem;
+            padding: 1.5rem;
+            box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3);
+            margin-bottom: 1.5rem;
+        }
+        .controls {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1.5rem;
+            margin-bottom: 1rem;
+        }
+        .control-group {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        label {
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: #94a3b8;
+        }
+        .compare-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            justify-content: center;
+            align-items: flex-start;
+            padding: 1rem;
+            background: #000;
+            border-radius: 0.5rem;
+        }
+        .level-box {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .level-box canvas {
+            border: 1px solid #334155;
+            background: #000;
+            max-width: 280px;
+            height: auto;
+        }
+        .level-label {
+            font-size: 0.75rem;
+            color: #64748b;
+        }
+        #histogram-canvas {
+            width: 100%;
+            height: 160px;
+            background: #000;
+            border-radius: 0.5rem;
+            display: block;
+        }
+        .scores {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 0.75rem;
+            font-size: 0.875rem;
+        }
+        .score-item {
+            background: #0f172a;
+            border: 1px solid #334155;
+            border-radius: 0.5rem;
+            padding: 0.5rem 0.75rem;
+        }
+        .score-item .name {
+            color: #94a3b8;
+            display: block;
+            font-size: 0.75rem;
+        }
+        .score-item .value {
+            color: var(--secondary);
+            font-weight: 600;
+        }
+        .uploader {
+            border: 2px dashed #334155;
+            padding: 2rem;
+            text-align: center;
+            border-radius: 1rem;
+            cursor: pointer;
+            transition: all 0.2s;
+            margin-bottom: 1rem;
+        }
+        .uploader:hover { border-color: var(--primary); background: rgba(67, 233, 123, 0.05); }
+        .uploader p { margin: 0; color: #94a3b8; }
+        .loading {
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(15, 23, 42, 0.8);
+            display: flex; justify-content: center; align-items: center; z-index: 100;
+        }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+    <div id="loader" class="loading">
+        <p>Initializing WASM...</p>
+    </div>
+
+    <div class="container">
+        <div class="header">
+            <h1>Histogram & CLAHE</h1>
+            <p>calc_hist, compare_hist, equalize_hist &amp; Contrast Limited Adaptive Histogram Equalization</p>
+        </div>
+
+        <div class="card">
+            <div id="drop-zone" class="uploader">
+                <p>Click or drag image here</p>
+                <input type="file" id="file-input" accept="image/*" class="hidden">
+            </div>
+
+            <div class="controls">
+                <div class="control-group">
+                    <label>CLAHE Clip Limit: <span id="val-clip">40</span></label>
+                    <input type="range" id="clip-limit" min="1" max="100" value="40">
+                </div>
+                <div class="control-group">
+                    <label>CLAHE Tile Grid: <span id="val-tiles">8</span>x<span id="val-tiles-2">8</span></label>
+                    <input type="range" id="tile-grid" min="2" max="16" value="8">
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div id="compare-row" class="compare-row">
+                <!-- Canvases injected here: Grayscale | equalize_hist | CLAHE -->
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="level-label" style="margin-bottom: 0.5rem;">256-bin uniform histogram of the grayscale source (calc_hist)</div>
+            <canvas id="histogram-canvas"></canvas>
+        </div>
+
+        <div class="card">
+            <div class="level-label" style="margin-bottom: 0.75rem;">compare_hist: source histogram vs. CLAHE-equalized histogram</div>
+            <div id="scores" class="scores">
+                <!-- Score items injected here -->
+            </div>
+        </div>
+    </div>
+
+    <script type="module" src="example_histogram.js"></script>
+</body>
+</html>

--- a/crates/wasm/www/example_histogram.html
+++ b/crates/wasm/www/example_histogram.html
@@ -159,7 +159,8 @@
             transition: all 0.2s;
             margin-bottom: 1rem;
         }
-        .uploader:hover { border-color: var(--primary); background: rgba(67, 233, 123, 0.05); }
+        .uploader:hover,
+        .uploader.drag-over { border-color: var(--primary); background: rgba(67, 233, 123, 0.05); }
         .uploader p { margin: 0; color: #94a3b8; }
         .loading {
             position: fixed;

--- a/crates/wasm/www/example_histogram.js
+++ b/crates/wasm/www/example_histogram.js
@@ -122,26 +122,36 @@ function processImage() {
     const clipLimit = parseFloat(clipSlider.value);
     const tileGrid = parseInt(tileSlider.value);
 
+    // Declared outside the try so a mid-way failure can still free whatever
+    // was already allocated (WASM objects are not garbage-collected).
+    let images = null;
+    let hist = null;
+    let equalized = null;
+    let clahe = null;
+    let claheOut = null;
+    let claheImages = null;
+    let claheHist = null;
+
     try {
         // --- calc_hist: 256-bin uniform histogram of the grayscale source ---
-        const images = new cv.MatVector();
+        images = new cv.MatVector();
         images.push(gray);
         const histSize = [256];
         const ranges = [0.0, 256.0];
-        const hist = cv.calcHistUniform(images, [0], undefined, histSize, ranges, false, undefined);
+        hist = cv.calcHistUniform(images, [0], undefined, histSize, ranges, false, undefined);
         drawHistogram(histCanvas, hist.dataF32(), '#43e97b');
 
         // --- equalize_hist: global histogram equalization ---
-        const equalized = cv.equalizeHist(gray);
+        equalized = cv.equalizeHist(gray);
 
         // --- CLAHE: contrast-limited adaptive histogram equalization ---
-        const clahe = new cv.Clahe(clipLimit, tileGrid, tileGrid);
-        const claheOut = clahe.apply(gray);
+        clahe = new cv.Clahe(clipLimit, tileGrid, tileGrid);
+        claheOut = clahe.apply(gray);
 
         // --- compare_hist: source vs. CLAHE-equalized histograms ---
-        const claheImages = new cv.MatVector();
+        claheImages = new cv.MatVector();
         claheImages.push(claheOut);
-        const claheHist = cv.calcHistUniform(claheImages, [0], undefined, histSize, ranges, false, undefined);
+        claheHist = cv.calcHistUniform(claheImages, [0], undefined, histSize, ranges, false, undefined);
 
         for (const method of COMPARE_METHODS) {
             const score = cv.compareHist(hist, claheHist, method.ctor(cv));
@@ -155,19 +165,18 @@ function processImage() {
         matToCanvas(gray, addCanvasBox(`Grayscale: ${gray.cols}x${gray.rows}`));
         matToCanvas(equalized, addCanvasBox('equalize_hist'));
         matToCanvas(claheOut, addCanvasBox(`CLAHE (clip=${clipLimit}, ${tileGrid}x${tileGrid})`));
-
-        hist.free();
-        equalized.free();
-        clahe.free();
-        claheOut.free();
-        claheHist.free();
-        images.free();
-        claheImages.free();
     } catch (e) {
         console.error("Histogram/CLAHE error:", e);
+    } finally {
+        gray.free();
+        images?.free();
+        hist?.free();
+        equalized?.free();
+        clahe?.free();
+        claheOut?.free();
+        claheImages?.free();
+        claheHist?.free();
     }
-
-    gray.free();
 }
 
 clipSlider.oninput = () => {
@@ -184,13 +193,29 @@ tileSlider.oninput = () => {
 const fileInput = document.getElementById('file-input');
 const dropZone = document.getElementById('drop-zone');
 
-dropZone.onclick = () => fileInput.click();
-fileInput.onchange = async (e) => {
-    if (e.target.files.length > 0) {
-        const url = URL.createObjectURL(e.target.files[0]);
+async function loadFile(file) {
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    try {
         sourceImage = await loadImage(url);
         processImage();
+    } finally {
+        URL.revokeObjectURL(url);
     }
+}
+
+dropZone.onclick = () => fileInput.click();
+fileInput.onchange = (e) => loadFile(e.target.files[0]);
+
+dropZone.ondragover = (e) => {
+    e.preventDefault();
+    dropZone.classList.add('drag-over');
+};
+dropZone.ondragleave = () => dropZone.classList.remove('drag-over');
+dropZone.ondrop = (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('drag-over');
+    loadFile(e.dataTransfer.files[0]);
 };
 
 start();

--- a/crates/wasm/www/example_histogram.js
+++ b/crates/wasm/www/example_histogram.js
@@ -1,0 +1,196 @@
+/*
+ *  example_histogram.js
+ *  purecv
+ *
+ *  This file is part of purecv - WebARKit.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { initWasm, loadImage, getScaledDimensions, canvasToMat, matToCanvas } from './cv_demo_utils.js';
+
+let sourceImage = null;
+let cv = null;
+const compareRow = document.getElementById('compare-row');
+const histCanvas = document.getElementById('histogram-canvas');
+const scoresEl = document.getElementById('scores');
+const clipSlider = document.getElementById('clip-limit');
+const clipDisplay = document.getElementById('val-clip');
+const tileSlider = document.getElementById('tile-grid');
+const tilesDisplay = document.getElementById('val-tiles');
+const tilesDisplay2 = document.getElementById('val-tiles-2');
+
+const COMPARE_METHODS = [
+    { name: 'Correl', ctor: (cv) => cv.HIST_CMP_CORREL() },
+    { name: 'ChiSqr', ctor: (cv) => cv.HIST_CMP_CHISQR() },
+    { name: 'ChiSqrAlt', ctor: (cv) => cv.HIST_CMP_CHISQR_ALT() },
+    { name: 'Intersect', ctor: (cv) => cv.HIST_CMP_INTERSECT() },
+    { name: 'Bhattacharyya', ctor: (cv) => cv.HIST_CMP_BHATTACHARYYA() },
+    { name: 'KL Divergence', ctor: (cv) => cv.HIST_CMP_KL_DIV() },
+];
+
+async function start() {
+    try {
+        cv = await initWasm();
+        document.getElementById('loader').classList.add('hidden');
+
+        sourceImage = await loadImage('https://raw.githubusercontent.com/opencv/opencv/master/samples/data/butterfly.jpg');
+        processImage();
+    } catch (err) {
+        console.error("WASM Initialization failed:", err);
+        document.getElementById('loader').innerHTML = `<p style="color:red">Error loading WASM: ${err.message}</p>`;
+    }
+}
+
+function addCanvasBox(label) {
+    const box = document.createElement('div');
+    box.className = 'level-box';
+
+    const canvas = document.createElement('canvas');
+    const text = document.createElement('span');
+    text.className = 'level-label';
+    text.innerText = label;
+
+    box.appendChild(canvas);
+    box.appendChild(text);
+    compareRow.appendChild(box);
+    return canvas;
+}
+
+function drawHistogram(canvas, histData, color) {
+    const w = canvas.clientWidth || 512;
+    const h = 160;
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, w, h);
+
+    const max = Math.max(...histData, 1);
+    const binWidth = w / histData.length;
+
+    ctx.fillStyle = color;
+    for (let i = 0; i < histData.length; i++) {
+        const barHeight = (histData[i] / max) * (h - 4);
+        ctx.fillRect(i * binWidth, h - barHeight, Math.max(binWidth, 1), barHeight);
+    }
+}
+
+function processImage() {
+    if (!sourceImage || !cv) return;
+
+    compareRow.innerHTML = '';
+    scoresEl.innerHTML = '';
+
+    const { width, height } = getScaledDimensions(sourceImage, 512);
+    const tempCanvas = document.createElement('canvas');
+    tempCanvas.width = width;
+    tempCanvas.height = height;
+    const tempCtx = tempCanvas.getContext('2d', "willReadFrequently: true");
+    tempCtx.drawImage(sourceImage, 0, 0, width, height);
+
+    const rgbaMat = canvasToMat(cv, tempCanvas, tempCtx);
+    const gray = cv.cvtColor(rgbaMat, cv.COLOR_RGBA2GRAY());
+    rgbaMat.free();
+
+    const clipLimit = parseFloat(clipSlider.value);
+    const tileGrid = parseInt(tileSlider.value);
+
+    try {
+        // --- calc_hist: 256-bin uniform histogram of the grayscale source ---
+        const images = new cv.MatVector();
+        images.push(gray);
+        const histSize = [256];
+        const ranges = [0.0, 256.0];
+        const hist = cv.calcHistUniform(images, [0], undefined, histSize, ranges, false, undefined);
+        drawHistogram(histCanvas, hist.dataF32(), '#43e97b');
+
+        // --- equalize_hist: global histogram equalization ---
+        const equalized = cv.equalizeHist(gray);
+
+        // --- CLAHE: contrast-limited adaptive histogram equalization ---
+        const clahe = new cv.Clahe(clipLimit, tileGrid, tileGrid);
+        const claheOut = clahe.apply(gray);
+
+        // --- compare_hist: source vs. CLAHE-equalized histograms ---
+        const claheImages = new cv.MatVector();
+        claheImages.push(claheOut);
+        const claheHist = cv.calcHistUniform(claheImages, [0], undefined, histSize, ranges, false, undefined);
+
+        for (const method of COMPARE_METHODS) {
+            const score = cv.compareHist(hist, claheHist, method.ctor(cv));
+            const item = document.createElement('div');
+            item.className = 'score-item';
+            item.innerHTML = `<span class="name">${method.name}</span><span class="value">${score.toFixed(4)}</span>`;
+            scoresEl.appendChild(item);
+        }
+
+        // --- render the three grayscale variants side by side ---
+        matToCanvas(gray, addCanvasBox(`Grayscale: ${gray.cols}x${gray.rows}`));
+        matToCanvas(equalized, addCanvasBox('equalize_hist'));
+        matToCanvas(claheOut, addCanvasBox(`CLAHE (clip=${clipLimit}, ${tileGrid}x${tileGrid})`));
+
+        hist.free();
+        equalized.free();
+        clahe.free();
+        claheOut.free();
+        claheHist.free();
+        images.free();
+        claheImages.free();
+    } catch (e) {
+        console.error("Histogram/CLAHE error:", e);
+    }
+
+    gray.free();
+}
+
+clipSlider.oninput = () => {
+    clipDisplay.innerText = clipSlider.value;
+    processImage();
+};
+
+tileSlider.oninput = () => {
+    tilesDisplay.innerText = tileSlider.value;
+    tilesDisplay2.innerText = tileSlider.value;
+    processImage();
+};
+
+const fileInput = document.getElementById('file-input');
+const dropZone = document.getElementById('drop-zone');
+
+dropZone.onclick = () => fileInput.click();
+fileInput.onchange = async (e) => {
+    if (e.target.files.length > 0) {
+        const url = URL.createObjectURL(e.target.files[0]);
+        sourceImage = await loadImage(url);
+        processImage();
+    }
+};
+
+start();

--- a/crates/wasm/www/index.html
+++ b/crates/wasm/www/index.html
@@ -124,6 +124,11 @@
             <h2>Image Pyramids</h2>
             <p>Construct and visualize a Gaussian pyramid stack at multiple scales.</p>
         </a>
+        <a href="example_histogram.html" class="example-card">
+            <span class="badge">Imgproc</span>
+            <h2>Histogram & CLAHE</h2>
+            <p>Compute histograms, compare distributions, and enhance contrast with global and adaptive (CLAHE) equalization.</p>
+        </a>
         <a href="example_hough_lines.html" class="example-card">
             <span class="badge">Hough</span>
             <h2>Line Detection</h2>

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -36,8 +36,7 @@
 
 use image::{DynamicImage, GenericImageView, ImageBuffer, Luma};
 use purecv::core::logging::tags;
-use purecv::core::types::Size2i;
-use purecv::core::Matrix;
+use purecv::core::{Matrix, Size2i};
 use purecv::imgproc::{
     calc_back_project, calc_hist, compare_hist, create_clahe, cvt_color_rgb_to_gray, equalize_hist,
     HistCompMethods, RangeSpec,
@@ -76,6 +75,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rgb_img = img.to_rgb8();
     let mat_rgb = Matrix::from_vec(height as usize, width as usize, 3, rgb_img.into_raw());
     let mat_gray = cvt_color_rgb_to_gray(&mat_rgb)?;
+
+    // Create output directory if it doesn't exist.
+    std::fs::create_dir_all("examples/data/out")?;
 
     // --- calc_hist: uniform bins ---
 

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -1,0 +1,203 @@
+/*
+ *  histogram.rs
+ *  purecv
+ *
+ *  This file is part of purecv - WebARKit.
+ *
+ *  purecv is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  purecv is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with purecv.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+use image::{DynamicImage, GenericImageView, ImageBuffer, Luma};
+use purecv::core::logging::tags;
+use purecv::core::types::Size2i;
+use purecv::core::Matrix;
+use purecv::imgproc::{
+    calc_back_project, calc_hist, compare_hist, create_clahe, cvt_color_rgb_to_gray, equalize_hist,
+    HistCompMethods, RangeSpec,
+};
+use purecv::version;
+use purecv::{cv_log_error, cv_log_info};
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    purecv::core::logging::init_basic_logger()?;
+
+    cv_log_info!(tags::PURECV, "--- Histogram & CLAHE Example ---");
+    version::print_version();
+
+    // 1. Load the image
+    let img_path = "examples/data/butterfly.jpg";
+    if !Path::new(img_path).exists() {
+        cv_log_error!(
+            tags::IMGPROC,
+            "{} not found. Run from the project root.",
+            img_path
+        );
+        return Ok(());
+    }
+
+    let img = image::open(img_path)?;
+    let (width, height) = img.dimensions();
+    cv_log_info!(
+        tags::IMGPROC,
+        "loaded image: {} ({}x{})",
+        img_path,
+        width,
+        height
+    );
+
+    let rgb_img = img.to_rgb8();
+    let mat_rgb = Matrix::from_vec(height as usize, width as usize, 3, rgb_img.into_raw());
+    let mat_gray = cvt_color_rgb_to_gray(&mat_rgb)?;
+
+    // --- calc_hist: uniform bins ---
+
+    cv_log_info!(tags::IMGPROC, "computing a 256-bin uniform histogram...");
+    let hist_size = [256usize];
+    let ranges = [RangeSpec::Uniform(0.0, 256.0)];
+    let hist = calc_hist(&[&mat_gray], &[0], None, &hist_size, &ranges, false, None)?;
+    print_histogram_summary(&hist);
+
+    // --- calc_hist: non-uniform bins ---
+    //
+    // Four unevenly-spaced bins: a wide shadow bucket, two mid-tone buckets,
+    // and a narrow highlight bucket.
+    cv_log_info!(tags::IMGPROC, "computing a 4-bin non-uniform histogram...");
+    let non_uniform_size = [4usize];
+    let boundaries = vec![0.0, 96.0, 160.0, 224.0, 256.0];
+    let non_uniform_ranges = [RangeSpec::NonUniform(boundaries)];
+    let non_uniform_hist = calc_hist(
+        &[&mat_gray],
+        &[0],
+        None,
+        &non_uniform_size,
+        &non_uniform_ranges,
+        false,
+        None,
+    )?;
+    println!(
+        "  non-uniform bins [0,96) [96,160) [160,224) [224,256): {:?}",
+        non_uniform_hist.data
+    );
+
+    // --- calc_back_project ---
+    //
+    // Projects the histogram back onto the source image: each pixel is
+    // replaced by its own bin's count, scaled for visibility. Bright
+    // regions in the output correspond to common intensities in the image.
+    // The scale is derived from the histogram's own peak so the output uses
+    // the full 0-255 display range, matching OpenCV's typical demo pattern.
+    cv_log_info!(tags::IMGPROC, "back-projecting the histogram...");
+    let max_bin = hist.data.iter().cloned().fold(0.0f32, f32::max);
+    let bp_scale = if max_bin > 0.0 { 255.0 / max_bin } else { 1.0 };
+    let back_projected =
+        calc_back_project(&[&mat_gray], &[0], &hist_size, &hist, &ranges, bp_scale)?;
+    let mut bp_u8 = Matrix::<u8>::new(back_projected.rows, back_projected.cols, 1);
+    for (dst, &src) in bp_u8.data.iter_mut().zip(back_projected.data.iter()) {
+        *dst = src.clamp(0.0, 255.0) as u8;
+    }
+    save_matrix_gray(&bp_u8, "examples/data/out/output_back_project.png")?;
+
+    // --- compare_hist ---
+    //
+    // Compare the source histogram against the histogram of a brightened
+    // copy of the same image, across every HistCompMethods variant.
+    cv_log_info!(tags::IMGPROC, "comparing histograms...");
+    let mut brightened = Matrix::<u8>::new(mat_gray.rows, mat_gray.cols, 1);
+    for (dst, &src) in brightened.data.iter_mut().zip(mat_gray.data.iter()) {
+        *dst = src.saturating_add(40);
+    }
+    let brightened_hist = calc_hist(&[&brightened], &[0], None, &hist_size, &ranges, false, None)?;
+
+    for method in [
+        HistCompMethods::Correl,
+        HistCompMethods::ChiSqr,
+        HistCompMethods::ChiSqrAlt,
+        HistCompMethods::Intersection,
+        HistCompMethods::Bhattacharyya,
+        HistCompMethods::KullbackLeibler,
+    ] {
+        let score = compare_hist(&hist, &brightened_hist, method)?;
+        println!("  {:?}: {:.4}", method, score);
+    }
+
+    // --- equalize_hist ---
+
+    cv_log_info!(tags::IMGPROC, "equalizing histogram...");
+    let equalized = equalize_hist(&mat_gray)?;
+    save_matrix_gray(&equalized, "examples/data/out/output_equalize_hist.png")?;
+
+    // --- CLAHE ---
+    //
+    // Contrast Limited Adaptive Histogram Equalization avoids over-amplifying
+    // noise in flat regions, unlike global equalize_hist above. Two tile
+    // grid sizes are compared: a coarser 4x4 grid and a finer 8x8 grid.
+    cv_log_info!(tags::IMGPROC, "applying CLAHE (4x4 tiles)...");
+    let clahe_coarse = create_clahe(40.0, Size2i::new(4, 4));
+    let clahe_coarse_out = clahe_coarse.apply_u8(&mat_gray)?;
+    save_matrix_gray(&clahe_coarse_out, "examples/data/out/output_clahe_4x4.png")?;
+
+    cv_log_info!(tags::IMGPROC, "applying CLAHE (8x8 tiles)...");
+    let clahe_fine = create_clahe(40.0, Size2i::new(8, 8));
+    let clahe_fine_out = clahe_fine.apply_u8(&mat_gray)?;
+    save_matrix_gray(&clahe_fine_out, "examples/data/out/output_clahe_8x8.png")?;
+
+    cv_log_info!(
+        tags::IMGPROC,
+        "done! Check the output_*.png files under examples/data/out/."
+    );
+    Ok(())
+}
+
+/// Prints the min/max/mean bin count and the 3 most populated bins of a
+/// flattened `f32` histogram (as returned by `calc_hist`).
+fn print_histogram_summary(hist: &Matrix<f32>) {
+    let data = &hist.data;
+    let total_bins = data.len();
+    let sum: f32 = data.iter().sum();
+    let mean = sum / total_bins as f32;
+    let max_bin = data
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .map(|(idx, &v)| (idx, v))
+        .unwrap_or((0, 0.0));
+    println!(
+        "  {total_bins} bins, total count {sum:.0}, mean {mean:.2}, most populated bin {} (count {:.0})",
+        max_bin.0, max_bin.1
+    );
+}
+
+fn save_matrix_gray(mat: &Matrix<u8>, filename: &str) -> image::ImageResult<()> {
+    let img: ImageBuffer<Luma<u8>, Vec<u8>> =
+        ImageBuffer::from_raw(mat.cols as u32, mat.rows as u32, mat.data.clone())
+            .expect("Failed to create image buffer");
+    DynamicImage::ImageLuma8(img).save(filename)
+}


### PR DESCRIPTION
## Summary

Closes #108.

- `examples/histogram.rs`: `calc_hist` (uniform and non-uniform bins),
  `calc_back_project`, `compare_hist` across all 6 `HistCompMethods`,
  `equalize_hist`, and `Clahe::apply_u8` at two tile-grid sizes. Loads
  `examples/data/butterfly.jpg` (matching `filters.rs`'s convention) and
  saves output PNGs under `examples/data/out/`.
- `crates/wasm/www/example_histogram.html` + `.js`: interactive demo matching
  the existing per-feature `example_*.html`/`.js` convention, reusing
  `cv_demo_utils.js`. Shows grayscale/`equalize_hist`/CLAHE side by side, a
  live `calc_hist` bar chart, and `compare_hist` scores against a
  CLAHE-equalized histogram, with clip-limit and tile-grid sliders. Linked
  from `crates/wasm/www/index.html`'s gallery.
- Root `README.md`: new `purecv-imgproc` bullet for histograms/CLAHE, added
  `cargo run --example histogram` to the Running Examples list, and updated
  the Imgproc module test-coverage bullet (308 → 342 unit tests).

## Test plan

- [x] `cargo run --example histogram` — confirmed by @kalwalt, produces all 4
      output PNGs (`output_back_project.png`, `output_equalize_hist.png`,
      `output_clahe_4x4.png`, `output_clahe_8x8.png`); also visually verified
      each output image before finalizing (back-projection scale is derived
      from the histogram's own peak bin, `255 / max_bin`, rather than a fixed
      guess, matching OpenCV's typical demo pattern).
- [x] `cargo fmt --check` / `clippy -D warnings` clean on the new example.
- [x] `cargo test --workspace`: 342 lib tests + 40 doc-tests passing.
- [x] WASM example verified end-to-end in a real browser — served
      `crates/wasm/` over HTTP, built the actual `wasm-pack` output, confirmed
      by @kalwalt as working ("wasm example works as a charme"). Interactive
      slider updates re-trigger `calc_hist`/`equalize_hist`/`Clahe`/`compare_hist`
      and re-render correctly.
