### PR TITLE
perf(ci): run the sequential (non-parallel) test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Run tests
       run: cargo test --workspace
 
+    - name: Run tests (sequential, parallel disabled)
+      run: cargo test --workspace --no-default-features --features std
+
     - name: Run tests (with parallel feature)
       run: cargo test --workspace --features parallel
 


### PR DESCRIPTION
## Summary

Closes #112.

CI never actually executed the `#[cfg(not(feature = "parallel"))]` code path
for any module — it was compiled (via the `no_std` job's `cargo
build`/`clippy`) but never run under `cargo test`. `cargo test --workspace`
uses the crate's `default = ["std", "parallel"]` feature set, so the
sequential fallback in every module was untested at runtime.

Adds a step running `cargo test --workspace --no-default-features --features
std` alongside the existing default/parallel/simd/ndarray feature runs.

## Test plan

- [x] Ran `cargo test --workspace --no-default-features --features std`
      locally before pushing — 342 lib tests + 40 doc-tests pass, no latent
      sequential/parallel divergence surfaced.
- [x] Validated `.github/workflows/ci.yml` YAML syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
