### PR TITLE
chore(release): prepare for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2026-09-02
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Pin stable toolchain and allow the new chunks_exact_to_as_chunks lint
+
+### ⚡ Performance
+
+- *(imgproc)* SIMD-accelerate compare_hist
+- *(imgproc)* SIMD-accelerate compare_hist
+- *(ci)* Run the sequential (non-parallel) test suite in CI
+
+### 🐛 Bug Fixes
+
+- *(imgproc)* Address review comments for histogram module
+- *(imgproc)* Guard calc_back_project against zero-width images
+- *(imgproc)* Address Qodo review comments for SIMD compare_hist
+- *(wasm)* Address Qodo review findings on histogram bindings
+- Address Qodo review findings on histogram examples
+
+### 📚 Documentation
+
+- Record the release workflow and merge policy in CLAUDE.md
+- Add histogram/CLAHE examples (Rust + WASM) and update READMEs
+
+### 🕸️ WebAssembly & Emscripten
+
+- *(wasm)* Expose histogram module bindings
+
+### 🚀 Features
+
+- *(imgproc)* Add histogram module
+- *(imgproc)* Add parallel support to histogram module
+
+### 🚜 Refactor
+
+- *(imgproc)* Use as_chunks instead of allowing the new clippy lint
+
+### 🧪 Testing
+
+- *(imgproc)* Move histogram module tests into src/imgproc/tests.rs
+
 ## [0.7.1] - 2026-08-10
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purecv"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Walter Perdan <https://github.com/kalwalt>"]
 edition = "2021"
 rust-version = "1.88"
@@ -86,7 +86,7 @@ members = ["crates/wasm"]
 exclude = ["crates/no-std-smoke"]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Walter Perdan <https://github.com/kalwalt>"]
 edition = "2021"
 description = "A pure Rust, high-performance computer vision library focused on safety and portability."

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,7 +28,11 @@ Publishing a new version requires a mix of manual changelog curation and automat
 2. Verify that all CI checks (Formatting, Clippy, Tests for `parallel` and `simd`) are passing on the latest commit.
 
 ### Step 2: Bump the Version
-Update the version number in the `Cargo.toml` file of the workspace in [package] and [workspace.package] sections. 
+Update the version number in the `Cargo.toml` file of the workspace in [package] and [workspace.package] sections, and in the root `package.json`.
+
+Also check `README.md` and `crates/wasm/README.md` for hardcoded version strings in
+installation snippets (e.g. `purecv = "0.6"`) — these don't update automatically and
+are easy to miss. Search for the old version number across both files before moving on.
 
 ### Step 3: Generate the Local Changelog
 We use `git-cliff` to parse the conventional commits and update the historical changelog. Run the following command in the root directory:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-purecv = "0.6"
+purecv = "0.8"
 ```
 
 PureCV's minimum supported Rust version (MSRV) is **1.88**.
@@ -105,7 +105,7 @@ PureCV's minimum supported Rust version (MSRV) is **1.88**.
 ### `no_std` / embedded support
 
 Build with `--no-default-features` to run on bare-metal targets such as the
-ESP32 (`purecv = { version = "0.6", default-features = false }`). Only `core`
+ESP32 (`purecv = { version = "0.8", default-features = false }`). Only `core`
 and `alloc` are required (an allocator must be provided by the target).
 
 | Module | `no_std` | Notes |
@@ -121,7 +121,7 @@ features gives the scalar, single-threaded code paths.
 
 ```toml
 [dependencies]
-purecv = { version = "0.6", default-features = false }
+purecv = { version = "0.8", default-features = false }
 ```
 
 ```rust
@@ -150,14 +150,14 @@ To enable the `ndarray` feature:
 
 ```toml
 [dependencies]
-purecv = { version = "0.6", features = ["ndarray"] }
+purecv = { version = "0.8", features = ["ndarray"] }
 ```
 
 To enable SIMD + Parallel for maximum performance:
 
 ```toml
 [dependencies]
-purecv = { version = "0.6", features = ["parallel", "simd"] }
+purecv = { version = "0.8", features = ["parallel", "simd"] }
 ```
 
 ### Usage Example

--- a/crates/wasm/pkg/package.json
+++ b/crates/wasm/pkg/package.json
@@ -5,7 +5,7 @@
                           "Walter Perdan \u003chttps://github.com/kalwalt\u003e"
                       ],
     "description":  "A pure Rust, high-performance computer vision library focused on safety and portability.",
-    "version":  "0.7.1",
+    "version":  "0.8.0",
     "license":  "LGPL-2.1-or-later",
     "repository":  {
                        "type":  "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purecv",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A pure Rust, high-performance computer vision library focused on safety and portability.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Release-prep for v0.8.0. This is a minor version bump (0.7.1 → 0.8.0) since it adds
a whole new feature area (the histogram/CLAHE module — `calc_hist`,
`calc_back_project`, `compare_hist`, `equalize_hist`, `Clahe`, with parallel + SIMD
support and WASM bindings) with no breaking changes to previously-released APIs,
matching this project's own precedent (0.6 → 0.7.0 was the last feature-sized bump;
0.7.0 → 0.7.1 was CI/Miri-only).

- Bump version in `Cargo.toml` ([package] + [workspace.package]) and root
  `package.json`. `crates/wasm/Cargo.toml` inherits via `version.workspace = true`.
- Regenerate `crates/wasm/pkg/package.json` via `npm run build`.
- Fix `README.md`'s hardcoded install-snippet version strings (still said `"0.6"` in
  five places — these don't update automatically with the version bump).
- Add a note to `MAINTAINERS.md`'s release checklist so this doesn't drift again.
- Generate the v0.8.0 `CHANGELOG.md` entry via `git-cliff`.

**Note:** this PR targets `dev`, not `main`. Per `CLAUDE.md`'s release process, the
actual release PR is a separate `dev` → `main` PR opened once this lands — its head
must literally be `dev` (not a side branch) to avoid the SHA-divergence issue that
hit v0.7.1/#95.

## Test plan

- [x] `cargo build --workspace` clean with the new version.
- [x] `cargo test --workspace`: 342 lib tests + 40 doc-tests passing.
- [x] `npm run build` (wasm dual build) succeeds, `crates/wasm/pkg/package.json`
      shows `"version": "0.8.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
